### PR TITLE
Uses Hal internal library instead of dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,8 +5,6 @@
   "require": {
     "php": ">= 5.6",
     "guzzlehttp/guzzle": "^6.3",
-    "jsor/hal-client": "^3.4",
-    "crell/api-problem": "^2.0",
     "shoppingfeed/php-feed-generator": "1.0.0-alpha.1"
   },
   "autoload": {
@@ -20,7 +18,6 @@
   "require-dev": {
     "monolog/monolog": "^1.23",
     "phpunit/phpunit": "^5.0",
-    "jsor/hal-client": "^3.4",
     "squizlabs/php_codesniffer": "^2.8"
   },
   "scripts": {

--- a/src/Api/Catalog/InventoryDomain.php
+++ b/src/Api/Catalog/InventoryDomain.php
@@ -6,7 +6,7 @@ use ShoppingFeed\Sdk\Resource\AbstractDomainResource;
 
 /**
  * @method ApiCatalog\InventoryResource[] getIterator()
- * @method ApiCatalog\InventoryResource[] getAll($page, $limit)
+ * @method ApiCatalog\InventoryResource[] getAll($page = 1, $limit = 100)
  */
 class InventoryDomain extends AbstractDomainResource
 {

--- a/src/Api/Store/StoreResource.php
+++ b/src/Api/Store/StoreResource.php
@@ -44,7 +44,7 @@ class StoreResource extends AbstractResource
     public function getInventory()
     {
         return new InventoryDomain(
-            $this->resource->getFirstLink('inventory')
+            $this->resource->getLink('inventory')
         );
     }
 }

--- a/src/Client/Client.php
+++ b/src/Client/Client.php
@@ -10,6 +10,8 @@ use ShoppingFeed\Sdk\Credential\CredentialInterface;
 
 class Client
 {
+    const VERSION = '1.0.0';
+
     /**
      * @var Hal\HalClient
      */

--- a/src/Credential/CredentialInterface.php
+++ b/src/Credential/CredentialInterface.php
@@ -1,14 +1,14 @@
 <?php
 namespace ShoppingFeed\Sdk\Credential;
 
-use Jsor\HalClient\HalClientInterface;
+use ShoppingFeed\Sdk\Hal;
 
 interface CredentialInterface
 {
     /**
-     * @param HalClientInterface $client
+     * @param Hal\HalClient $client
      *
      * @return \ShoppingFeed\Sdk\Api\Session\SessionResource
      */
-    public function authenticate(HalClientInterface $client);
+    public function authenticate(Hal\HalClient $client);
 }

--- a/src/Credential/Password.php
+++ b/src/Credential/Password.php
@@ -1,7 +1,7 @@
 <?php
 namespace ShoppingFeed\Sdk\Credential;
 
-use Jsor\HalClient\HalClientInterface;
+use ShoppingFeed\Sdk\Hal;
 
 class Password implements CredentialInterface
 {
@@ -28,10 +28,10 @@ class Password implements CredentialInterface
     /**
      * @inheritdoc
      */
-    public function authenticate(HalClientInterface $client)
+    public function authenticate(Hal\HalClient $client)
     {
-        $response = $client->post('v1/auth', [
-            'body' => [
+        $response = $client->request('POST', 'v1/auth', [
+            'json' => [
                 'grant_type' => 'password',
                 'username'   => $this->username,
                 'password'   => $this->password,

--- a/src/Credential/Token.php
+++ b/src/Credential/Token.php
@@ -1,7 +1,7 @@
 <?php
 namespace ShoppingFeed\Sdk\Credential;
 
-use Jsor\HalClient\HalClientInterface;
+use ShoppingFeed\Sdk\Hal;
 use ShoppingFeed\Sdk\Api\Session\SessionResource;
 
 class Token implements CredentialInterface
@@ -22,12 +22,12 @@ class Token implements CredentialInterface
     /**
      * @inheritdoc
      */
-    public function authenticate(HalClientInterface $client)
+    public function authenticate(Hal\HalClient $client)
     {
-        $client = $client->withHeader('Authorization', 'Bearer ' . $this->token);
+        $client = $client->withToken($this->token);
 
         return new SessionResource(
-            $client->get('v1/me'),
+            $client->request('GET', 'v1/me'),
             false
         );
     }

--- a/src/Hal/HalClient.php
+++ b/src/Hal/HalClient.php
@@ -1,0 +1,147 @@
+<?php
+namespace ShoppingFeed\Sdk\Hal;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Middleware;
+use GuzzleHttp\Pool;
+use GuzzleHttp\Psr7\Request;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+
+class HalClient
+{
+    /**
+     * @var HandlerStack
+     */
+    private $stack;
+
+    /**
+     * @var Client
+     */
+    private $client;
+
+    /**
+     * @var string
+     */
+    private $baseUri;
+
+    /**
+     * @param              $baseUri
+     * @param HandlerStack $stack
+     */
+    public function __construct($baseUri, HandlerStack $stack = null)
+    {
+        $this->baseUri = $baseUri;
+        $this->createClient($stack);
+    }
+
+    /**
+     * @param $token
+     *
+     * @return HalClient
+     */
+    public function withToken($token)
+    {
+        $stack = clone $this->stack;
+        $stack->push(Middleware::mapRequest(function (RequestInterface $request) use ($token) {
+            return $request->withHeader('Authorization', 'Bearer ' . trim($token));
+        }));
+
+        $instance = clone $this;
+        $instance->createClient($stack);
+
+        return $instance;
+    }
+
+    /**
+     * @param string $method
+     * @param string $uri
+     *
+     * @param array  $headers
+     * @param null   $body
+     *
+     * @return RequestInterface
+     */
+    public function createRequest($method, $uri, array $headers = [], $body = null)
+    {
+        return new Request($method, $uri, $headers, $body);
+    }
+
+    /**
+     * @param $method
+     * @param $uri
+     * @param $options
+     *
+     * @return null|HalResource
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     */
+    public function request($method, $uri, array $options = [])
+    {
+        return $this->send(
+            $this->createRequest($method, $uri),
+            $options
+        );
+    }
+
+    /**
+     * @param       $requests
+     * @param array $config
+     *
+     * @return void
+     */
+    public function batchSend($requests, array $config = [])
+    {
+        $pool = new Pool($this->client, $requests, $config);
+        $pool->promise()->wait(true);
+    }
+
+    /**
+     * @param RequestInterface $request
+     * @param array            $options
+     *
+     * @return null|HalResource
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     */
+    public function send(RequestInterface $request, array $options = [])
+    {
+        $response = $this->client->send($request, $options);
+        if ($response instanceof ResponseInterface) {
+            return $this->createResource($response);
+        }
+
+        return null;
+    }
+
+    /**
+     * @param ResponseInterface $response
+     *
+     * @return HalResource
+     */
+    public function createResource(ResponseInterface $response)
+    {
+        return HalResource::fromArray(
+            $this,
+            \GuzzleHttp\json_decode($response->getBody(), true)
+        );
+    }
+
+    /**
+     * @param HandlerStack $stack
+     */
+    private function createClient(HandlerStack $stack = null)
+    {
+        if (null === $stack) {
+            $stack = HandlerStack::create();
+        }
+
+        $this->stack  = $stack;
+        $this->client = new Client([
+            'handler'  => $this->stack,
+            'base_uri' => $this->baseUri,
+            'headers'  => [
+                'Accept' => 'application/json'
+            ]
+        ]);
+    }
+}

--- a/src/Hal/HalLink.php
+++ b/src/Hal/HalLink.php
@@ -1,0 +1,296 @@
+<?php
+namespace ShoppingFeed\Sdk\Hal;
+
+use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\UriTemplate;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+
+class HalLink
+{
+    /**
+     * @var UriTemplate
+     */
+    private static $uriTemplate;
+
+    /**
+     * @var string
+     */
+    private $href;
+
+    /**
+     * @var bool
+     */
+    private $templated;
+
+    /**
+     * @var string
+     */
+    private $type;
+
+    /**
+     * @var string
+     */
+    private $name;
+
+    /**
+     * @var string
+     */
+    private $title;
+
+    /**
+     * @var HalClient
+     */
+    private $client;
+
+    /**
+     * @param HalClient $client
+     * @param           $href
+     * @param array     $config
+     */
+    public function __construct(HalClient $client, $href, array $config = [])
+    {
+        $this->href   = $href;
+        $this->client = $client;
+
+        if (isset($config['templated'])) {
+            $this->templated = (bool) $config['templated'];
+        }
+        if (isset($config['type'])) {
+            $this->type = $config['type'];
+        }
+        if (isset($config['name'])) {
+            $this->name = $config['name'];
+        }
+        if (isset($config['title'])) {
+            $this->title = $config['title'];
+        }
+    }
+
+    /**
+     * @return string
+     */
+    public function getHref()
+    {
+        return $this->href;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isTemplated()
+    {
+        return $this->templated;
+    }
+
+    /**
+     * @return string
+     */
+    public function getType()
+    {
+        return $this->type;
+    }
+
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * @return string
+     */
+    public function getTitle()
+    {
+        return $this->title;
+    }
+
+    /**
+     * @param array $variables
+     *
+     * @return null|string|string[]
+     */
+    public function getUri(array $variables)
+    {
+        if (! $this->isTemplated()) {
+           return $this->getHref();
+        }
+
+        if (null === static::$uriTemplate) {
+            static::$uriTemplate = new UriTemplate();
+        }
+
+        return static::$uriTemplate->expand($this->getHref(), $variables);
+    }
+
+    /**
+     * @param array $variables
+     * @param array $options
+     *
+     * @return null|HalResource
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     */
+    public function get(array $variables = [], array $options = [])
+    {
+        return $this->client->send(
+            $this->createRequest('GET', $variables),
+            $options
+        );
+    }
+
+    /**
+     * @param mixed $data
+     * @param array $variables
+     * @param array $options
+     *
+     * @return null|HalResource
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     */
+    public function put($data, array $variables = [], array $options = [])
+    {
+        return $this->client->send(
+            $this->createRequest('PUT', $variables, $data),
+            $options
+        );
+    }
+
+    /**
+     * @param mixed $data
+     * @param array $variables
+     * @param array $options
+     *
+     * @return null|HalResource
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     */
+    public function patch($data, array $variables = [], array $options = [])
+    {
+        return $this->client->send(
+            $this->createRequest('PATCH', $variables, $data),
+            $options
+        );
+    }
+
+    /**
+     * @param mixed $data
+     * @param array $variables
+     * @param array $options
+     *
+     * @return null|HalResource
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     */
+    public function post($data, array $variables = [], array $options = [])
+    {
+        return $this->client->send(
+            $this->createRequest('POST', $variables, $data),
+            $options
+        );
+    }
+
+    /**
+     * @param mixed $data
+     * @param array $variables
+     * @param array $options
+     *
+     * @return null|HalResource
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     */
+    public function delete($data, array $variables = [], array $options = [])
+    {
+        return $this->client->send(
+            $this->createRequest('DELETE', $variables, $data),
+            $options
+        );
+    }
+
+    /**
+     * @param          $requests
+     * @param callable $success
+     * @param callable $error
+     * @param array    $options
+     * @param int      $concurrency
+     *
+     * @return void
+     */
+    public function batchSend(
+        $requests,
+        callable $success = null,
+        callable $error = null,
+        array $options = [],
+        $concurrency = 10
+    )
+    {
+        $config['concurrency'] = (int) $concurrency;
+        $config['fulfilled']   = $this->createResponseCallback($success);
+        $config['rejected']    = $this->createExceptionCallback($error);
+
+        if ($options) {
+            $config['options'] = $options;
+        }
+
+        $this->client->batchSend($requests, $config);
+    }
+
+    /**
+     * @param RequestInterface|RequestInterface[] $request
+     * @param array                               $config
+     *
+     * @return null|HalResource
+     */
+    public function send($request, array $config = [])
+    {
+        return $this->client->send($request, $config);
+    }
+
+    /**
+     * @param       $method
+     * @param array $variables
+     * @param array $body
+     *
+     * @return \Psr\Http\Message\RequestInterface
+     */
+    public function createRequest($method, array $variables = [], $body = null)
+    {
+        $uri     = $this->getUri($variables);
+        $method  = strtoupper($method);
+        $headers = [];
+
+        if (! isset($headers['Content-Type']) && in_array($method, ['POST', 'PUT', 'PATCH'])) {
+            $headers['Content-Type'] = 'application/json';
+            $body = \GuzzleHttp\json_encode($body);
+        }
+
+        return $this->client->createRequest($method, $uri, $headers, $body);
+    }
+
+    /**
+     * @param callable|null $callback
+     *
+     * @return \Closure
+     */
+    private function createResponseCallback(callable $callback = null)
+    {
+        return function(ResponseInterface $response) use($callback) {
+            if ($callback) {
+                $resource = $this->client->createResource($response);
+                call_user_func($callback, $resource);
+            }
+        };
+    }
+
+    /**
+     * @param callable|null $callback
+     *
+     * @return \Closure
+     */
+    private function createExceptionCallback(callable $callback = null)
+    {
+        return function(RequestException $exception) use($callback) {
+            if ($exception->hasResponse() && $callback) {
+                $resource = $this->client->createResource($exception->getResponse());
+                call_user_func($callback, $resource);
+            }
+        };
+    }
+}

--- a/src/Hal/HalResource.php
+++ b/src/Hal/HalResource.php
@@ -1,0 +1,181 @@
+<?php
+namespace ShoppingFeed\Sdk\Hal;
+
+class HalResource
+{
+    /**
+     * @var array
+     */
+    private $properties = [];
+
+    /**
+     * @var array
+     */
+    private $links = [];
+
+    /**
+     * @var array
+     */
+    private $embedded = [];
+
+    /**
+     * @param HalClient $client
+     * @param array     $data
+     *
+     * @return static
+     */
+    public static function fromArray(HalClient $client, array $data)
+    {
+        $links    = [];
+        $embedded = [];
+
+        if (isset($data['_links'])) {
+            $links = $data['_links'];
+            unset($data['_links']);
+        }
+
+        if (isset($data['_embedded'])) {
+            $embedded = $data['_embedded'];
+            unset($data['_embedded']);
+        }
+
+        return new static($client, $data, $links, $embedded);
+    }
+
+    /**
+     * @param HalClient $client
+     * @param array     $properties
+     * @param array     $links
+     * @param array     $embedded
+     */
+    public function __construct(HalClient $client, array $properties = [], array $links = [], array $embedded = [])
+    {
+        $this->properties = $properties;
+
+        $this->createLinks($client, $links);
+        $this->createEmbedded($client, $embedded);
+    }
+
+    /**
+     * @param string $name
+     *
+     * @return bool
+     */
+    public function hasProperty($name)
+    {
+        return array_key_exists($name, $this->properties);
+    }
+
+    /**
+     * @param      $name
+     * @param null $default
+     *
+     * @return mixed|null
+     */
+    public function getProperty($name, $default = null)
+    {
+        if (isset($this->properties[$name])) {
+            return $this->properties[$name];
+        }
+
+        return $default;
+    }
+
+    /**
+     * @return array
+     */
+    public function getProperties()
+    {
+        return $this->properties;
+    }
+
+    /**
+     * @param string $rel The resource identifier
+     *
+     * @return static[]
+     */
+    public function getResources($rel)
+    {
+        if (isset($this->embedded[$rel])) {
+            return $this->embedded[$rel];
+        }
+
+        return [];
+    }
+
+    /**
+     * @return static[][]
+     */
+    public function getAllResources()
+    {
+        return $this->embedded;
+    }
+
+    /**
+     * @param string $rel The resource identifier
+     *
+     * @return static|null
+     */
+    public function getFirstResource($rel)
+    {
+        $resources = $this->getResources($rel);
+        if ($resources) {
+            return $resources[0];
+        }
+
+        return null;
+    }
+
+    /**
+     * @param string $rel The resource identifier
+     *
+     * @return HalLink|null
+     */
+    public function getLink($rel)
+    {
+        if (isset($this->links[$rel])) {
+            return $this->links[$rel];
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array $options
+     *
+     * @return null|HalResource
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     */
+    public function get(array $options = [])
+    {
+        return $this->getLink('self')->get([], $options);
+    }
+
+    /**
+     * @param array $links
+     * @param HalClient $client
+     */
+    private function createLinks(HalClient $client, array $links)
+    {
+        foreach ($links as $rel => $link) {
+            $this->links[$rel] = new HalLink($client, $link['href'], $link);
+        }
+    }
+
+    /**
+     * @param HalClient $client
+     * @param array     $relations
+     */
+    private function createEmbedded(HalClient $client, array $relations)
+    {
+        foreach ($relations as $name => $resources) {
+            if (array_values($resources) !== $resources) {
+                $resources = [$resources];
+            }
+
+            foreach ($resources as $index => $resource) {
+                $this->embedded[$name][$index] = static::fromArray($client, $resource);
+            }
+        }
+    }
+}

--- a/src/Operation/AbstractBulkOperation.php
+++ b/src/Operation/AbstractBulkOperation.php
@@ -1,9 +1,6 @@
 <?php
 namespace ShoppingFeed\Sdk\Operation;
 
-use Crell\ApiProblem\ApiProblem;
-use Jsor\HalClient\Exception\BadResponseException;
-
 abstract class AbstractBulkOperation extends AbstractOperation
 {
     /**
@@ -18,7 +15,7 @@ abstract class AbstractBulkOperation extends AbstractOperation
      *
      * @var int
      */
-    private $poolSize = 1;
+    private $poolSize = 10;
 
     /**
      * @var array
@@ -47,6 +44,22 @@ abstract class AbstractBulkOperation extends AbstractOperation
         $this->poolSize = max(1, $poolSize);
 
         return $this;
+    }
+
+    /**
+     * @return int
+     */
+    public function getBatchSize()
+    {
+        return $this->batchSize;
+    }
+
+    /**
+     * @return int
+     */
+    public function getPoolSize()
+    {
+        return $this->poolSize;
     }
 
     /**

--- a/src/Operation/AbstractOperation.php
+++ b/src/Operation/AbstractOperation.php
@@ -1,40 +1,14 @@
 <?php
 namespace ShoppingFeed\Sdk\Operation;
 
-use Jsor\HalClient\HalLink;
-use Jsor\HalClient\HalResource;
+use ShoppingFeed\Sdk\Hal;
 
 abstract class AbstractOperation
 {
     /**
-     * @param HalLink $link
+     * @param Hal\HalLink $link
      *
      * @return mixed
      */
-    abstract public function execute(HalLink $link);
-
-    /**
-     * @return string
-     */
-    abstract public function getRelatedResource();
-
-    /**
-     * @param HalResource $resource
-     *
-     * @return HalResource[]
-     */
-    protected function getRelated(HalResource $resource)
-    {
-        return $resource->getResource($this->getRelatedResource());
-    }
-
-    /**
-     * @param mixed $data
-     *
-     * @return array
-     */
-    protected function createHttpBody($data)
-    {
-        return ['body' => [$this->getRelatedResource() => $data]];
-    }
+    abstract public function execute(Hal\HalLink $link);
 }

--- a/src/Resource/AbstractCollection.php
+++ b/src/Resource/AbstractCollection.php
@@ -1,7 +1,7 @@
 <?php
 namespace ShoppingFeed\Sdk\Resource;
 
-use Jsor\HalClient\HalResource;
+use ShoppingFeed\Sdk\Hal;
 use Traversable;
 
 abstract class AbstractCollection extends AbstractResource implements \Countable, \IteratorAggregate
@@ -78,7 +78,7 @@ abstract class AbstractCollection extends AbstractResource implements \Countable
     {
         $className = $this->resourceClass;
         foreach ($resources as $resource) {
-            if ($resource instanceof HalResource) {
+            if ($resource instanceof Hal\HalResource) {
                 $resource = new $className($resource, true);
             }
             $this->resources[] = $resource;

--- a/src/Resource/AbstractDomainResource.php
+++ b/src/Resource/AbstractDomainResource.php
@@ -1,14 +1,14 @@
 <?php
 namespace ShoppingFeed\Sdk\Resource;
 
-use Jsor\HalClient\HalLink;
+use ShoppingFeed\Sdk\Hal;
 
 abstract class AbstractDomainResource
 {
-    const PER_PAGE = 100;
+    const PER_PAGE = 200;
 
     /**
-     * @var HalLink
+     * @var Hal\HalLink
      */
     protected $link;
 
@@ -18,9 +18,9 @@ abstract class AbstractDomainResource
     protected $resourceClass = '';
 
     /**
-     * @param HalLink $link
+     * @param Hal\HalLink $link
      */
-    public function __construct(HalLink $link)
+    public function __construct(Hal\HalLink $link)
     {
         $this->link = $link;
     }

--- a/src/Resource/AbstractResource.php
+++ b/src/Resource/AbstractResource.php
@@ -1,13 +1,12 @@
 <?php
 namespace ShoppingFeed\Sdk\Resource;
 
-use Jsor\HalClient\HalLink;
-use Jsor\HalClient\HalResource;
+use ShoppingFeed\Sdk\Hal;
 
 abstract class AbstractResource implements \JsonSerializable
 {
     /**
-     * @var HalResource
+     * @var Hal\HalResource
      */
     protected $resource;
 
@@ -17,10 +16,10 @@ abstract class AbstractResource implements \JsonSerializable
     private $isPartial;
 
     /**
-     * @param HalResource $resource
+     * @param Hal\HalResource $resource
      * @param bool        $isPartial
      */
-    public function __construct(HalResource $resource, $isPartial = true)
+    public function __construct(Hal\HalResource $resource, $isPartial = true)
     {
         $this->resource  = $resource;
         $this->isPartial = $isPartial;
@@ -119,10 +118,10 @@ abstract class AbstractResource implements \JsonSerializable
     /**
      * @param string $name
      *
-     * @return HalLink|null
+     * @return Hal\HalLink|null
      */
     protected function getLink($name)
     {
-        return $this->resource->getFirstLink($name);
+        return $this->resource->getLink($name);
     }
 }

--- a/src/Resource/PaginatedResourceCollection.php
+++ b/src/Resource/PaginatedResourceCollection.php
@@ -1,7 +1,7 @@
 <?php
 namespace ShoppingFeed\Sdk\Resource;
 
-use Jsor\HalClient\HalResource;
+use ShoppingFeed\Sdk\Hal;
 
 class PaginatedResourceCollection extends AbstractResource implements \IteratorAggregate, \Countable
 {
@@ -11,10 +11,10 @@ class PaginatedResourceCollection extends AbstractResource implements \IteratorA
     private $resourceClass;
 
     /**
-     * @param HalResource $resource
-     * @param string      $resourceClass
+     * @param Hal\HalResource $resource
+     * @param string          $resourceClass
      */
-    public function __construct(HalResource $resource, $resourceClass)
+    public function __construct(Hal\HalResource $resource, $resourceClass)
     {
         $this->resourceClass = (string) $resourceClass;
 
@@ -58,12 +58,13 @@ class PaginatedResourceCollection extends AbstractResource implements \IteratorA
      */
     public function next()
     {
-        if (! $this->resource->hasLink('next')) {
+        $link = $this->resource->getLink('next');
+        if (! $link) {
             return null;
         }
 
-        $link = $this->resource->getFirstLink('next');
-        if (! $resource = $link->get()) {
+        $resource = $link->get();
+        if (! $resource) {
             return null;
         }
 
@@ -75,7 +76,7 @@ class PaginatedResourceCollection extends AbstractResource implements \IteratorA
      */
     public function getIterator()
     {
-        $data = current($this->resource->getResources()) ?: [];
+        $data = current($this->resource->getAllResources()) ?: [];
         foreach ($data as $item) {
             yield new $this->resourceClass($item);
         }


### PR DESCRIPTION
Removing jsor/hal-client allow us to unlock the following features:

- Forward custom options to guzzle http client
- Ability to perform requests in parallel (see inventory update)
- Take the control of the underlying (GuzzleHttp) client if needed