### PR TITLE
Add Gzip as accepted encoding

### DIFF
--- a/src/Hal/HalClient.php
+++ b/src/Hal/HalClient.php
@@ -137,8 +137,9 @@ class HalClient
             'handler'    => $this->stack,
             'base_uri'   => $this->baseUri,
             'headers'    => [
-                'Accept'     => 'application/json',
-                'User-Agent' => 'SF-SDK-PHP/' . SdkClient::VERSION
+                'Accept'          => 'application/json',
+                'User-Agent'      => 'SF-SDK-PHP/' . SdkClient::VERSION,
+                'Accept-Encoding' => 'gzip',
             ]
         ]);
     }


### PR DESCRIPTION
#This PR enables zlib output compression from api as default setting for the whole SDK.

A max paginated order resource GET request, without gzip (Look at the Content-Length):

```
HTTP/1.1 200 OK
Vary: Authorization,User-Agent,Accept-Encoding
Content-Type: application/hal+json
Content-Length: 160819
```

Then with `Accept-Encoding: gzip` header : 

```
HTTP/1.1 200 OK
Vary: Authorization,User-Agent,Accept-Encoding
Content-Type: application/hal+json
Content-Length: 14094
```