### PR TITLE
Adding unit tests for Operation

### DIFF
--- a/tests/unit/Operation/AbstractBulkOperationTest.php
+++ b/tests/unit/Operation/AbstractBulkOperationTest.php
@@ -1,0 +1,45 @@
+<?php
+namespace ShoppingFeed\Sdk\Test\Operation;
+
+use PHPUnit\Framework\TestCase;
+use ShoppingFeed\Sdk\Operation\AbstractBulkOperation;
+
+class AbstractBulkOperationTest extends TestCase
+{
+    public function testGetterSetters()
+    {
+        /** @var AbstractBulkOperation $instance */
+        $instance = $this->getMockForAbstractClass(AbstractBulkOperation::class);
+
+        $instance
+            ->setBatchSize(10)
+            ->setPoolSize(20);
+
+        $this->assertEquals(10, $instance->getBatchSize());
+        $this->assertEquals(20, $instance->getPoolSize());
+    }
+
+    public function testEachBatchCallback()
+    {
+        $operations = [];
+        for ($i = 0; $i <= 50; $i++) {
+            $operations[] = 'operation' . $i;
+        };
+        $instance = new BulkOperationMock($operations);
+        $instance->setBatchSize(2);
+
+        $count    = 0;
+        $opeCount = count($operations);
+        $tester   = $this;
+        $instance->eachBatch(
+            function ($chunck) use ($tester, $opeCount, &$count) {
+                if ($opeCount % 2 && $opeCount - $count === 1) {
+                    $tester->assertCount(1, $chunck);
+                } else {
+                    $tester->assertCount(2, $chunck);
+                    $count += 2;
+                }
+            }
+        );
+    }
+}

--- a/tests/unit/Operation/BulkOperationMock.php
+++ b/tests/unit/Operation/BulkOperationMock.php
@@ -1,0 +1,28 @@
+<?php
+namespace ShoppingFeed\Sdk\Test\Operation;
+
+use ShoppingFeed\Sdk\Hal;
+use ShoppingFeed\Sdk\Operation\AbstractBulkOperation;
+
+class BulkOperationMock extends AbstractBulkOperation
+{
+    /**
+     * @var array
+     */
+    private $operation;
+
+    public function __construct($operations = [])
+    {
+        $this->operations = $operations;
+    }
+
+    public function eachBatch(callable $callback)
+    {
+        parent::eachBatch($callback);
+    }
+
+    public function execute(Hal\HalLink $link)
+    {
+        return 'Called';
+    }
+}


### PR DESCRIPTION
**How to test**
1. Checkout the PR
2. Run `docker-compose run sf-php-sdk-dev composer test` at the root of the project.

_If you get an isset error in `ServerHandlerError` you can apply this fix localy https://github.com/shoppingflux/php-sdk/pull/30/files#diff-5a9b41debf506875db35eb932b3445b4R41_