### PR TITLE
Adding unit tests for Resource

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,8 @@
   },
   "autoload": {
     "psr-4": {
-      "ShoppingFeed\\Sdk\\": "src/"
+      "ShoppingFeed\\Sdk\\": "src/",
+      "ShoppingFeed\\Sdk\\Test\\": "tests/unit"
     }
   },
   "suggest": {

--- a/tests/unit/Resource/AbstractCollectionTest.php
+++ b/tests/unit/Resource/AbstractCollectionTest.php
@@ -1,0 +1,88 @@
+<?php
+namespace ShoppingFeed\Sdk\Test\Resource;
+
+use PHPUnit\Framework\TestCase;
+use ShoppingFeed\Sdk\Hal;
+use ShoppingFeed\Sdk\Resource;
+
+class AbstractCollectionTest extends TestCase
+{
+    /**
+     * @var array
+     */
+    private $data;
+
+    /**
+     * @var Resource\AbstractCollection|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $collection;
+
+    public function setUp()
+    {
+        for ($i = 0; $i < 10; $i++) {
+            $this->data[] = $this->createMock(Hal\HalResource::class);
+        }
+
+        $this->collection = new CollectionMock($this->data);
+    }
+
+    public function testAddResources()
+    {
+        foreach ($this->collection as $resource) {
+            $this->assertInstanceOf(ResourceMock::class, $resource);
+        }
+    }
+
+    public function testCount()
+    {
+        $this->assertCount(count($this->data), $this->collection);
+    }
+
+    public function testMerge()
+    {
+        $this->collection->merge(new CollectionMock($this->data));
+
+        $this->assertCount(count($this->data) * 2, $this->collection);
+    }
+
+    public function testToArray()
+    {
+        $expected = $this->dataToArray();
+
+        $this->assertEquals($expected, $this->collection->toArray());
+    }
+
+    public function testJsonSerialization()
+    {
+        $expected = $this->dataToArray();
+
+        $this->assertEquals($expected, $this->collection->jsonSerialize());
+    }
+
+    public function testIterator()
+    {
+        $expected = new \ArrayIterator(
+            array_map(
+                function (Hal\HalResource $resource) {
+                    return new ResourceMock($resource);
+                },
+                $this->data
+            )
+        );
+
+        $this->assertEquals($expected, $this->collection->getIterator());
+    }
+
+    /**
+     * @return array
+     */
+    private function dataToArray()
+    {
+        $expected = [];
+        foreach ($this->data as $resource) {
+            $expected[] = (new ResourceMock($resource))->toArray();
+        }
+
+        return $expected;
+    }
+}

--- a/tests/unit/Resource/AbstractDomainResourceTest.php
+++ b/tests/unit/Resource/AbstractDomainResourceTest.php
@@ -61,6 +61,56 @@ class AbstractDomainResourceTest extends TestCase
         $this->assertEquals(($totalItems / $perPage) - ($pageFrom - 1), $count);
     }
 
+    public function testGetAll()
+    {
+
+        $pages = [
+            [
+                $this->createMock(HalResource::class),
+                $this->createMock(HalResource::class),
+                $this->createMock(HalResource::class),
+                $this->createMock(HalResource::class),
+            ],
+            [
+                $this->createMock(HalResource::class),
+                $this->createMock(HalResource::class),
+                $this->createMock(HalResource::class),
+                $this->createMock(HalResource::class),
+            ],
+        ];
+        $link  = $this->createMock(HalLink::class);
+
+        $instance = $this
+            ->getMockBuilder(DomainResourceMock::class)
+            ->setConstructorArgs([$link])
+            ->setMethods(['getPages'])
+            ->getMock();
+
+        $instance
+            ->expects($this->once())
+            ->method('getPages')
+            ->with(10, 15)
+            ->will($this->returnCallback(
+                function ($fromPage, $perPage) use ($pages) {
+                    foreach ($pages as $page) {
+                        yield $page;
+                    }
+                }
+            ));
+
+        $count = 0;
+        foreach ($instance->getAll(10, 15) as $resource) {
+            $count++;
+        }
+
+        $awaited = 0;
+        foreach ($pages as $page) {
+            $awaited += count($page);
+        }
+
+        $this->assertEquals($awaited, $count);
+    }
+
     /**
      * Recurse to simulate load of next link
      *

--- a/tests/unit/Resource/AbstractDomainResourceTest.php
+++ b/tests/unit/Resource/AbstractDomainResourceTest.php
@@ -1,0 +1,36 @@
+<?php
+namespace ShoppingFeed\Sdk\Test\Resource;
+
+use PHPUnit\Framework\TestCase;
+use ShoppingFeed\Sdk\Hal\HalLink;
+use ShoppingFeed\Sdk\Hal\HalResource;
+use ShoppingFeed\Sdk\Resource\PaginatedResourceCollection;
+
+class AbstractDomainResourceTest extends TestCase
+{
+    public function testGetPageNullOnDeadLink()
+    {
+        $link = $this->createMock(HalLink::class);
+        $link
+            ->expects($this->once())
+            ->method('get')
+            ->willReturn(null);
+
+        $instance = new DomainResourceMock($link);
+
+        $this->assertNull($instance->getPage());
+    }
+
+    public function testGetPage()
+    {
+        $link = $this->createMock(HalLink::class);
+        $link
+            ->expects($this->once())
+            ->method('get')
+            ->willReturn($this->createMock(HalResource::class));
+
+        $instance = new DomainResourceMock($link);
+
+        $this->assertInstanceOf(PaginatedResourceCollection::class, $instance->getPage());
+    }
+}

--- a/tests/unit/Resource/AbstractResourceTest.php
+++ b/tests/unit/Resource/AbstractResourceTest.php
@@ -1,0 +1,181 @@
+<?php
+namespace ShoppingFeed\Sdk\Test\Resource;
+
+use PHPUnit\Framework\TestCase;
+use ShoppingFeed\Sdk\Hal\HalClient;
+use ShoppingFeed\Sdk\Hal\HalResource;
+use ShoppingFeed\Sdk\Resource\AbstractResource;
+
+class AbstractResourceTest extends TestCase
+{
+    /**
+     * @var HalResource|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $halResource;
+
+    /**
+     * @var array
+     */
+    private $data;
+
+    public function setUp()
+    {
+        $this->halResource = $this->createMock(HalResource::class);
+        $this->data        = [
+            'prop1' => 'value1',
+            'prop2' => 1,
+            'prop3' => true,
+            'prop4' => 'now',
+        ];
+    }
+
+    /**
+     * @return AbstractResource|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private function getInstance()
+    {
+        return $this->getMockForAbstractClass(
+            AbstractResource::class,
+            [$this->halResource],
+            '',
+            true,
+            true,
+            true,
+            ['initialize']
+        );
+    }
+
+    public function testRefresh()
+    {
+        $instance = $this->getInstance();
+
+        $instance
+            ->expects($this->once())
+            ->method('initialize')
+            ->with(true);
+
+        $instance->refresh();
+    }
+
+    public function testArraySerialization()
+    {
+        $this
+            ->halResource
+            ->expects($this->once())
+            ->method('getProperties')
+            ->willReturn($this->data);
+
+        $instance = $this->getInstance();
+
+        $this->assertEquals($this->data, $instance->toArray());
+    }
+
+    public function testJsonSerialization()
+    {
+        $this
+            ->halResource
+            ->expects($this->once())
+            ->method('getProperties')
+            ->willReturn($this->data);
+
+        $instance = $this->getInstance();
+
+        $this->assertEquals($this->data, $instance->jsonSerialize());
+    }
+
+    public function testGetProperty()
+    {
+        $this
+            ->halResource
+            ->expects($this->exactly(3))
+            ->method('getProperty');
+
+        $instance = new ResourceMock($this->halResource);
+
+        $instance->getProperty('prop1');
+        $instance->getProperty('prop2');
+        $instance->getProperty('prop3');
+    }
+
+    public function testGetPropertyMatch()
+    {
+        $data = $this->data;
+        $this
+            ->halResource
+            ->expects($this->exactly(3))
+            ->method('getProperty')
+            ->will(
+                $this->returnCallback(
+                    function ($prop) use ($data) {
+                        return $data[$prop];
+                    }
+                )
+            );
+
+        $instance = new ResourceMock($this->halResource);
+
+        $this->assertTrue($instance->propertyMatch('prop1', 'value1'));
+        $this->assertTrue($instance->propertyMatch('prop2', 1));
+        $this->assertTrue($instance->propertyMatch('prop3', true));
+    }
+
+    /**
+     * @throws \Exception
+     */
+    public function testGetPropertyDatetime()
+    {
+        $this
+            ->halResource
+            ->expects($this->once())
+            ->method('getProperty')
+            ->with('prop4')
+            ->willReturn('now');
+
+        $instance = new ResourceMock($this->halResource);
+
+        $this->assertEquals(new \DateTimeImmutable(), $instance->getPropertyDatetime('prop4'));
+    }
+
+    /**
+     * @throws \Exception
+     */
+    public function testGetPropertyDatetimeNull()
+    {
+        $this
+            ->halResource
+            ->expects($this->once())
+            ->method('getProperty')
+            ->with('prop4')
+            ->willReturn(null);
+
+        $instance = new ResourceMock($this->halResource);
+
+        $this->assertNull($instance->getPropertyDatetime('prop4'));
+    }
+
+    public function testInitialize()
+    {
+        $this
+            ->halResource
+            ->expects($this->once())
+            ->method('get');
+
+        $instance = new ResourceMock($this->halResource);
+
+        $instance->initialize(true);
+        $this->assertFalse($instance->isPartial());
+    }
+
+    public function testGetLink()
+    {
+        $this
+            ->halResource
+            ->expects($this->once())
+            ->method('getLink')
+            ->with('name');
+
+        $instance = new ResourceMock($this->halResource);
+
+        $instance->getLink('name');
+    }
+}

--- a/tests/unit/Resource/CollectionMock.php
+++ b/tests/unit/Resource/CollectionMock.php
@@ -1,0 +1,9 @@
+<?php
+namespace ShoppingFeed\Sdk\Test\Resource;
+
+use ShoppingFeed\Sdk\Resource\AbstractCollection;
+
+class CollectionMock extends AbstractCollection
+{
+    protected $resourceClass = ResourceMock::class;
+}

--- a/tests/unit/Resource/DomainResourceMock.php
+++ b/tests/unit/Resource/DomainResourceMock.php
@@ -1,0 +1,9 @@
+<?php
+namespace ShoppingFeed\Sdk\Test\Resource;
+
+use ShoppingFeed\Sdk\Resource\AbstractDomainResource;
+
+class DomainResourceMock extends AbstractDomainResource
+{
+
+}

--- a/tests/unit/Resource/PaginatedResourceCollectionTest.php
+++ b/tests/unit/Resource/PaginatedResourceCollectionTest.php
@@ -174,4 +174,30 @@ class PaginatedResourceCollectionTest extends TestCase
 
         $this->assertNull($instance->next());
     }
+
+    public function testGetIterator()
+    {
+        $resources = [
+            $this->createMock(HalResource::class),
+            $this->createMock(HalResource::class),
+            $this->createMock(HalResource::class),
+            $this->createMock(HalResource::class),
+        ];
+        $resource  = $this->createMock(HalResource::class);
+        $resource
+            ->expects($this->once())
+            ->method('getAllResources')
+            ->willReturn([$resources]);
+
+        $instance = new PaginatedResourceCollection($resource, ResourceMock::class);
+
+        $count = 0;
+        foreach ($instance->getIterator() as $i => $item) {
+            $count++;
+            $this->assertInstanceOf(ResourceMock::class, $item);
+            $this->assertEquals(new ResourceMock($resources[$i]), $item);
+        }
+
+        $this->assertEquals(count($resources), $count);
+    }
 }

--- a/tests/unit/Resource/PaginatedResourceCollectionTest.php
+++ b/tests/unit/Resource/PaginatedResourceCollectionTest.php
@@ -1,0 +1,177 @@
+<?php
+namespace ShoppingFeed\Sdk\Test\Resource;
+
+
+use PHPUnit\Framework\TestCase;
+use ShoppingFeed\Sdk\Hal\HalLink;
+use ShoppingFeed\Sdk\Hal\HalResource;
+use ShoppingFeed\Sdk\Resource\PaginatedResourceCollection;
+
+class PaginatedResourceCollectionTest extends TestCase
+{
+    public function testGetTotalCount()
+    {
+        $instance = $this
+            ->getMockBuilder(PaginatedResourceCollection::class)
+            ->setConstructorArgs(
+                [
+                    $this->createMock(HalResource::class),
+                    ResourceMock::class,
+                ]
+            )
+            ->setMethods(['getProperty'])
+            ->getMock();
+
+        $instance
+            ->expects($this->once())
+            ->method('getProperty')
+            ->with('total')
+            ->willReturn(15);
+
+        $this->assertEquals(15, $instance->getTotalCount());
+    }
+
+    public function testGetCurrentCount()
+    {
+        $instance = $this
+            ->getMockBuilder(PaginatedResourceCollection::class)
+            ->setConstructorArgs(
+                [
+                    $this->createMock(HalResource::class),
+                    ResourceMock::class,
+                ]
+            )
+            ->setMethods(['getProperty'])
+            ->getMock();
+
+        $instance
+            ->expects($this->once())
+            ->method('getProperty')
+            ->with('count')
+            ->willReturn(10);
+
+        $this->assertEquals(10, $instance->getCurrentCount());
+    }
+
+    public function testCount()
+    {
+        $instance = $this
+            ->getMockBuilder(PaginatedResourceCollection::class)
+            ->setConstructorArgs(
+                [
+                    $this->createMock(HalResource::class),
+                    ResourceMock::class,
+                ]
+            )
+            ->setMethods(['getCurrentCount'])
+            ->getMock();
+
+        $instance
+            ->expects($this->once())
+            ->method('getCurrentCount')
+            ->willReturn(18);
+
+        $this->assertEquals(18, $instance->count());
+    }
+
+    public function testGetTotalPages()
+    {
+        $instance = $this
+            ->getMockBuilder(PaginatedResourceCollection::class)
+            ->setConstructorArgs(
+                [
+                    $this->createMock(HalResource::class),
+                    ResourceMock::class,
+                ]
+            )
+            ->setMethods(['getProperty'])
+            ->getMock();
+
+        $instance
+            ->expects($this->once())
+            ->method('getProperty')
+            ->with('pages')
+            ->willReturn(5);
+
+        $this->assertEquals(5, $instance->getTotalPages());
+    }
+
+    public function testGetCurrentPage()
+    {
+        $instance = $this
+            ->getMockBuilder(PaginatedResourceCollection::class)
+            ->setConstructorArgs(
+                [
+                    $this->createMock(HalResource::class),
+                    ResourceMock::class,
+                ]
+            )
+            ->setMethods(['getProperty'])
+            ->getMock();
+
+        $instance
+            ->expects($this->once())
+            ->method('getProperty')
+            ->with('page')
+            ->willReturn(8);
+
+        $this->assertEquals(8, $instance->getCurrentPage());
+    }
+
+    public function testNext()
+    {
+        $link     = $this->createMock(HalLink::class);
+        $resource = $this->createMock(HalResource::class);
+
+        $link
+            ->expects($this->once())
+            ->method('get')
+            ->willReturn($this->createMock(HalResource::class));
+
+        $resource
+            ->expects($this->once())
+            ->method('getLink')
+            ->with('next')
+            ->willReturn($link);
+
+        $instance = new PaginatedResourceCollection($resource, ResourceMock::class);
+
+        $this->assertInstanceOf(PaginatedResourceCollection::class, $instance->next());
+    }
+
+    public function testNextNoLink()
+    {
+        $resource = $this->createMock(HalResource::class);
+
+        $resource
+            ->expects($this->once())
+            ->method('getLink')
+            ->with('next')
+            ->willReturn(null);
+
+        $instance = new PaginatedResourceCollection($resource, ResourceMock::class);
+
+        $this->assertNull($instance->next());
+    }
+
+    public function testNextNoResource()
+    {
+        $link     = $this->createMock(HalLink::class);
+        $resource = $this->createMock(HalResource::class);
+
+        $link
+            ->expects($this->once())
+            ->method('get')
+            ->willReturn(null);
+
+        $resource
+            ->expects($this->once())
+            ->method('getLink')
+            ->with('next')
+            ->willReturn($link);
+
+        $instance = new PaginatedResourceCollection($resource, ResourceMock::class);
+
+        $this->assertNull($instance->next());
+    }
+}

--- a/tests/unit/Resource/ResourceMock.php
+++ b/tests/unit/Resource/ResourceMock.php
@@ -1,0 +1,37 @@
+<?php
+namespace ShoppingFeed\Sdk\Test\Resource;
+
+use ShoppingFeed\Sdk\Resource\AbstractResource;
+
+class ResourceMock extends AbstractResource
+{
+    public function getProperty($property)
+    {
+        return parent::getProperty($property);
+    }
+
+    public function propertyMatch($property, $value)
+    {
+        return parent::propertyMatch($property, $value);
+    }
+
+    public function getPropertyDatetime($property)
+    {
+        return parent::getPropertyDatetime($property);
+    }
+
+    public function initialize($force = false)
+    {
+        return parent::initialize($force);
+    }
+
+    public function isPartial()
+    {
+        return parent::isPartial();
+    }
+
+    public function getLink($name)
+    {
+        return parent::getLink($name);
+    }
+}

--- a/tests/unit/Resource/ResourceMock.php
+++ b/tests/unit/Resource/ResourceMock.php
@@ -3,6 +3,11 @@ namespace ShoppingFeed\Sdk\Test\Resource;
 
 use ShoppingFeed\Sdk\Resource\AbstractResource;
 
+/**
+ * Class ResourceMock to be able to test some protected method of AbstractResource
+ *
+ * @package ShoppingFeed\Sdk\Test\Resource
+ */
 class ResourceMock extends AbstractResource
 {
     public function getProperty($property)


### PR DESCRIPTION
**How to test**
1. Checkout the PR
2. Run `docker-compose run sf-php-sdk-dev composer test` at the root of the project.

_If you get an isset error in `ServerHandlerError` you can apply this fix localy https://github.com/shoppingflux/php-sdk/pull/30/files#diff-5a9b41debf506875db35eb932b3445b4R41_