### PR TITLE
Adding unit tests for Hal

### DIFF
--- a/src/Hal/HalResource.php
+++ b/src/Hal/HalResource.php
@@ -152,12 +152,17 @@ class HalResource
     }
 
     /**
-     * @param array $links
+     * @param array     $links
      * @param HalClient $client
      */
     private function createLinks(HalClient $client, array $links)
     {
         foreach ($links as $rel => $link) {
+            if ($link instanceof HalLink) {
+                $this->links[$rel] = $link;
+                continue;
+            }
+
             $this->links[$rel] = new HalLink($client, $link['href'], $link);
         }
     }

--- a/tests/unit/Hal/HalClientTest.php
+++ b/tests/unit/Hal/HalClientTest.php
@@ -1,0 +1,125 @@
+<?php
+namespace ShoppingFeed\Sdk\Test\Hal;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Psr7\Request;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use ShoppingFeed\Sdk\Hal\HalClient;
+use ShoppingFeed\Sdk\Hal\HalResource;
+
+class HalClientTest extends TestCase
+{
+    public function testCreateRequest()
+    {
+        $instance = new HalClient('http://fake.uri');
+        $request  = $instance->createRequest('GET', '/test', ['FakeHeader' => 'HeaderValue'], 'test');
+
+        $this->assertInstanceOf(RequestInterface::class, $request);
+        $this->assertEquals('test', $request->getBody());
+        $this->assertEquals('HeaderValue', $request->getHeaderLine('FakeHeader'));
+        $this->assertEquals('GET', $request->getMethod());
+        $this->assertEquals('/test', $request->getUri());
+    }
+
+    public function testRequest()
+    {
+        /** @var HalClient|\PHPUnit_Framework_MockObject_MockObject $instance */
+        $instance = $this
+            ->getMockBuilder(HalClient::class)
+            ->setConstructorArgs(['http://fake.uri'])
+            ->setMethods(['send', 'createRequest'])
+            ->getMock();
+
+        $instance
+            ->expects($this->once())
+            ->method('send')
+            ->willReturn(true);
+        $instance
+            ->expects($this->once())
+            ->method('createRequest')
+            ->willReturn($this->createMock(Request::class));
+
+        $this->assertTrue($instance->request('GET', '/test'));
+    }
+
+    public function testCreateResource()
+    {
+        $response = $this->createMock(ResponseInterface::class);
+        $response
+            ->expects($this->once())
+            ->method('getBody')
+            ->willReturn('{"foo":"bar", "foo2":"bar2"}');
+
+        $instance = new HalClient('http://fake.uri');
+        $resource = $instance->createResource($response);
+
+        $this->assertInstanceOf(HalResource::class, $resource);
+    }
+
+    public function testWithToken()
+    {
+        $instance = new HalClient('http://fake.uri');
+        $client   = $instance->withToken('3213213132132131');
+
+        $this->assertInstanceOf(HalClient::class, $client);
+        $this->assertNotSame($instance, $client);
+    }
+
+    /**
+     * @throws \ReflectionException
+     */
+    public function testSend()
+    {
+        $clientInstanceMock = $this
+            ->getMockBuilder(HalClient::class)
+            ->setConstructorArgs(['http://fake.uri'])
+            ->setMethods(['createResource'])
+            ->getMock();
+        $clientInstance = new HalClient('http://fake.uri');
+        $reflection     = new \ReflectionClass($clientInstance);
+        $client         = $this->createMock(Client::class);
+
+        $client
+            ->expects($this->once())
+            ->method('send')
+            ->willReturn(
+                $this->createMock(ResponseInterface::class)
+            );
+
+        $clientProp = $reflection->getProperty('client');
+        $clientProp->setAccessible(true);
+        $clientProp->setValue($clientInstanceMock, $client);
+
+        $clientInstanceMock
+            ->expects($this->once())
+            ->method('createResource')
+            ->willReturn($this->createMock(HalResource::class));
+
+        $clientInstanceMock->send($this->createMock(RequestInterface::class));
+    }
+
+    /**
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @throws \ReflectionException
+     */
+    public function testSendNoResponse()
+    {
+        $clientInstance = new HalClient('http://fake.uri');
+        $reflection     = new \ReflectionClass($clientInstance);
+        $client         = $this->createMock(Client::class);
+
+        $client
+            ->expects($this->once())
+            ->method('send')
+            ->willReturn(null);
+
+        $clientProp = $reflection->getProperty('client');
+        $clientProp->setAccessible(true);
+        $clientProp->setValue($clientInstance, $client);
+
+        $result = $clientInstance->send($this->createMock(RequestInterface::class));
+        $this->assertNull($result);
+    }
+}

--- a/tests/unit/Hal/HalLinkTest.php
+++ b/tests/unit/Hal/HalLinkTest.php
@@ -1,0 +1,10 @@
+<?php
+namespace ShoppingFeed\Sdk\Test\Hal;
+
+use PHPUnit\Framework\TestCase;
+
+class HalLinkTest extends TestCase
+{
+
+
+}

--- a/tests/unit/Hal/HalLinkTest.php
+++ b/tests/unit/Hal/HalLinkTest.php
@@ -2,9 +2,184 @@
 namespace ShoppingFeed\Sdk\Test\Hal;
 
 use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\RequestInterface;
+use ShoppingFeed\Sdk\Hal\HalClient;
+use ShoppingFeed\Sdk\Hal\HalLink;
+use ShoppingFeed\Sdk\Hal\HalResource;
 
 class HalLinkTest extends TestCase
 {
+    public function testSetters()
+    {
+        $client   = $this->createMock(HalClient::class);
+        $instance = new HalLink(
+            $client,
+            'http://base.url',
+            [
+                'templated' => true,
+                'type'      => 'Type',
+                'name'      => 'Name',
+                'title'     => 'Title',
+            ]
+        );
 
+        $this->assertEquals('Type', $instance->getType());
+        $this->assertEquals('Name', $instance->getName());
+        $this->assertEquals('Title', $instance->getTitle());
+        $this->assertEquals('http://base.url', $instance->getHref());
+        $this->assertTrue($instance->isTemplated());
+    }
 
+    /**
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     */
+    public function testHttpClientCalls()
+    {
+        $client = $this->createMock(HalClient::class);
+        $client
+            ->expects($this->exactly(5))
+            ->method('send')
+            ->willReturn(
+                $this->createMock(HalResource::class)
+            );
+
+        $instance = $this
+            ->getMockBuilder(HalLink::class)
+            ->setConstructorArgs([$client, 'http://base.url'])
+            ->setMethods(['createRequest'])
+            ->getMock();
+
+        $instance
+            ->expects($this->exactly(5))
+            ->method('createRequest')
+            ->willReturn(
+                $this->createMock(RequestInterface::class)
+            );
+
+        $instance->get();
+        $instance->delete([]);
+        $instance->put([]);
+        $instance->patch([]);
+        $instance->post([]);
+    }
+
+    public function testSend()
+    {
+        $client = $this->createMock(HalClient::class);
+        $client
+            ->expects($this->once())
+            ->method('send')
+            ->willReturn(
+                $this->createMock(HalResource::class)
+            );
+
+        $instance = $this
+            ->getMockBuilder(HalLink::class)
+            ->setConstructorArgs([$client, 'http://base.url'])
+            ->setMethods(['createRequest'])
+            ->getMock();
+
+        $instance->send(
+            $this->createMock(RequestInterface::class)
+        );
+    }
+
+    public function testGetCreateRequest()
+    {
+        $client = $this->createMock(HalClient::class);
+        $client
+            ->expects($this->once())
+            ->method('createRequest')
+            ->willReturn(
+                $this->createMock(RequestInterface::class)
+            );
+
+        $instance = $this
+            ->getMockBuilder(HalLink::class)
+            ->setConstructorArgs([$client, 'http://base.url'])
+            ->setMethods(['getUri'])
+            ->getMock();
+
+        $instance
+            ->expects($this->once())
+            ->method('getUri')
+            ->willReturn('/fake/uri');
+
+        $instance->createRequest('GET');
+    }
+
+    public function testCreateRequestWithContent()
+    {
+        $client = $this->createMock(HalClient::class);
+        $client
+            ->expects($this->exactly(3))
+            ->method('createRequest')
+            ->willReturn(
+                $this->createMock(RequestInterface::class)
+            );
+
+        $instance = $this
+            ->getMockBuilder(HalLink::class)
+            ->setConstructorArgs([$client, 'http://base.url'])
+            ->setMethods(['getUri'])
+            ->getMock();
+
+        $instance
+            ->expects($this->exactly(3))
+            ->method('getUri')
+            ->willReturn('/fake/uri');
+
+        $instance->createRequest('POST');
+        $instance->createRequest('PUT');
+        $instance->createRequest('PATCH');
+    }
+
+    public function testBatchSend()
+    {
+        $client = $this->createMock(HalClient::class);
+        $client
+            ->expects($this->once())
+            ->method('batchSend');
+
+        $instance = new HalLink($client, 'http://base.url');
+
+        $instance->batchSend([]);
+    }
+
+    public function testBatchSendWithOption()
+    {
+        $client = $this->createMock(HalClient::class);
+        $client
+            ->expects($this->once())
+            ->method('batchSend');
+
+        $instance = new HalLink($client, 'http://base.url');
+
+        $instance->batchSend([], null, null, ['test' => 'option']);
+    }
+
+    public function testGetUriDefault()
+    {
+        $client   = $this->createMock(HalClient::class);
+        $instance = $this
+            ->getMockBuilder(HalLink::class)
+            ->setConstructorArgs([$client, 'http://base.url'])
+            ->setMethods(['getHref'])
+            ->getMock();
+
+        $instance
+            ->expects($this->once())
+            ->method('getHref')
+            ->willReturn('');
+
+        $instance->getUri([]);
+    }
+
+    public function testGetUriTemplated()
+    {
+        $client   = $this->createMock(HalClient::class);
+        $instance = new HalLink($client, 'http://base.url', ['templated' => true]);
+
+        $this->assertInternalType('string', $instance->getUri([]));
+    }
 }

--- a/tests/unit/Hal/HalResourceTest.php
+++ b/tests/unit/Hal/HalResourceTest.php
@@ -1,0 +1,244 @@
+<?php
+namespace ShoppingFeed\Sdk\Test\Hal;
+
+use PHPUnit\Framework\TestCase;
+use ShoppingFeed\Sdk\Hal\HalClient;
+use ShoppingFeed\Sdk\Hal\HalLink;
+use ShoppingFeed\Sdk\Hal\HalResource;
+
+class HalResourceTest extends TestCase
+{
+    /**
+     * @var array
+     */
+    private $links;
+
+    /**
+     * @var array
+     */
+    private $embedded;
+
+    /**
+     * @var array
+     */
+    private $properties;
+
+    public function setUp()
+    {
+        $this->properties = [
+            'prop1' => 1,
+            'prop2' => 'val2',
+            'prop3' => true,
+        ];
+        $this->embedded   = [
+            'rel1' => ['id' => 123],
+            'rel2' => ['id' => 456],
+        ];
+        $this->links      = [
+            'link1' => ['href' => 'http://link1'],
+            'link2' => ['href' => 'http://link2'],
+        ];
+    }
+
+    public function testHasProperty()
+    {
+        $client   = $this->createMock(HalClient::class);
+        $instance = new HalResource($client, $this->properties);
+
+        $this->assertTrue($instance->hasProperty('prop1'));
+        $this->assertTrue($instance->hasProperty('prop2'));
+        $this->assertTrue($instance->hasProperty('prop3'));
+    }
+
+    public function testGetProperty()
+    {
+        $client   = $this->createMock(HalClient::class);
+        $instance = new HalResource($client, $this->properties);
+
+        foreach ($this->properties as $prop => $val) {
+            $this->assertEquals($val, $instance->getProperty($prop));
+        }
+    }
+
+    public function testGetPropertyDefault()
+    {
+        $client   = $this->createMock(HalClient::class);
+        $instance = new HalResource($client, $this->properties);
+
+        $this->assertEquals(
+            'defaultValue',
+            $instance->getProperty('unexistingProp', 'defaultValue')
+        );
+    }
+
+    public function testGetProperties()
+    {
+        $client   = $this->createMock(HalClient::class);
+        $instance = new HalResource($client, $this->properties);
+
+        $this->assertEquals(
+            $this->properties,
+            $instance->getProperties()
+        );
+    }
+
+    public function testGetLink()
+    {
+        $client               = $this->createMock(HalClient::class);
+        $this->links['link3'] = new HalLink($client, 'http://link3');
+        $instance             = new HalResource($client, [], $this->links);
+
+        $this->assertEquals(
+            $this->createsLinks($client)['link1'],
+            $instance->getLink('link1')
+        );
+    }
+
+    public function testGet()
+    {
+        $client   = $this->createMock(HalClient::class);
+        $resource = $this->createMock(HalResource::class);
+        $link     = $this->createMock(HalLink::class);
+        $link
+            ->expects($this->once())
+            ->method('get')
+            ->willReturn($resource);
+
+        $instance = $this
+            ->getMockBuilder(HalResource::class)
+            ->setConstructorArgs([$client])
+            ->setMethods(['getLink'])
+            ->getMock();
+
+        $instance
+            ->expects($this->once())
+            ->method('getLink')
+            ->with('self')
+            ->willReturn($link);
+
+        $this->assertEquals($resource, $instance->get());
+    }
+
+    public function testGetLinkMissing()
+    {
+        $client   = $this->createMock(HalClient::class);
+        $instance = new HalResource($client, [], $this->links);
+
+        $this->assertNull($instance->getLink('linkMissing'));
+    }
+
+    public function testGetResources()
+    {
+        $client   = $this->createMock(HalClient::class);
+        $instance = new HalResource($client, [], [], $this->embedded);
+
+        $this->assertEquals(
+            $this->embeddingResources($client)['rel1'],
+            $instance->getResources('rel1')
+        );
+    }
+
+    public function testGetFirstResources()
+    {
+        $client   = $this->createMock(HalClient::class);
+        $instance = $this
+            ->getMockBuilder(HalResource::class)
+            ->setConstructorArgs([$client, [], [], $this->embedded])
+            ->setMethods(['getResources'])
+            ->getMock();
+
+        $instance
+            ->expects($this->once())
+            ->method('getResources')
+            ->willReturn([HalResource::fromArray($client, $this->embedded['rel1'])]);
+
+        $this->assertEquals(
+            $this->embeddingResources($client)['rel1'][0],
+            $instance->getFirstResource('rel1')
+        );
+    }
+
+    public function testGetFirstResourcesMissing()
+    {
+        $client   = $this->createMock(HalClient::class);
+        $instance = $this
+            ->getMockBuilder(HalResource::class)
+            ->setConstructorArgs([$client, [], [], $this->embedded])
+            ->setMethods(['getResources'])
+            ->getMock();
+
+        $instance
+            ->expects($this->once())
+            ->method('getResources')
+            ->willReturn(null);
+
+        $this->assertNull($instance->getFirstResource('rel1'));
+    }
+
+    public function testGetResourcesMissing()
+    {
+        $client   = $this->createMock(HalClient::class);
+        $instance = new HalResource($client);
+
+        $this->assertEquals([], $instance->getResources('rel1'));
+    }
+
+    public function testGetAllResources()
+    {
+        $client   = $this->createMock(HalClient::class);
+        $instance = new HalResource($client, [], [], $this->embedded);
+
+        $this->assertEquals(
+            $this->embeddingResources($client),
+            $instance->getAllResources()
+        );
+    }
+
+    public function testFromArray()
+    {
+        $client   = $this->createMock(HalClient::class);
+        $resource = HalResource::fromArray(
+            $client,
+            [
+                '_links'    => $this->links,
+                '_embedded' => $this->embedded,
+            ]
+        );
+
+        $this->assertInstanceOf(HalResource::class, $resource);
+    }
+
+    /**
+     * Format embedded data
+     *
+     * @param HalClient $client
+     *
+     * @return array
+     */
+    private function embeddingResources(HalClient $client)
+    {
+        return array_map(
+            function ($resourceData) use ($client) {
+                return [HalResource::fromArray($client, $resourceData)];
+            },
+            $this->embedded
+        );
+    }
+
+    /**
+     * Format embedded data
+     *
+     * @param HalClient $client
+     *
+     * @return array
+     */
+    private function createsLinks(HalClient $client)
+    {
+        return array_map(
+            function ($linkData) use ($client) {
+                return $linkData instanceof HalLink ? $linkData : new HalLink($client, $linkData['href'], $linkData);
+            },
+            $this->links
+        );
+    }
+}


### PR DESCRIPTION
**How to test**
1. Checkout the PR
2. Run `docker-compose run sf-php-sdk-dev composer test` at the root of the project.

_If you get an isset error in `ServerHandlerError` you can apply this fix localy https://github.com/shoppingflux/php-sdk/pull/30/files#diff-5a9b41debf506875db35eb932b3445b4R41_