### PR TITLE
Adding unit tests for Credential

### DIFF
--- a/src/Credential/Password.php
+++ b/src/Credential/Password.php
@@ -38,6 +38,16 @@ class Password implements CredentialInterface
             ],
         ]);
 
-        return (new Token($response->getProperty('access_token')))->authenticate($client);
+        return $this->tokenizeResponse($response)->authenticate($client);
+    }
+
+    /**
+     * @param Hal\HalResource $response
+     *
+     * @return Token
+     */
+    public function tokenizeResponse(Hal\HalResource $response)
+    {
+        return new Token($response->getProperty('access_token'));
     }
 }

--- a/tests/unit/Credential/PasswordTest.php
+++ b/tests/unit/Credential/PasswordTest.php
@@ -1,0 +1,52 @@
+<?php
+namespace ShoppingFeed\Sdk\Test\Credential;
+
+use PHPUnit\Framework\TestCase;
+use ShoppingFeed\Sdk;
+
+class PasswordTest extends TestCase
+{
+    public function testAuthenticate()
+    {
+        $token    = $this->createMock(Sdk\Credential\Token::class);
+        $response = $this->createMock(Sdk\Hal\HalResource::class);
+        $client   = $this->createMock(Sdk\Hal\HalClient::class);
+        $client
+            ->expects($this->once())
+            ->method('request')
+            ->willReturn($response);
+
+        $instance = $this
+            ->getMockBuilder(Sdk\Credential\Password::class)
+            ->setConstructorArgs(['username', 'password'])
+            ->setMethods(['tokenizeResponse'])
+            ->getMock();
+
+        $token
+            ->expects($this->once())
+            ->method('authenticate')
+            ->willReturn($this->createMock(Sdk\Api\Session\SessionResource::class));
+
+        $instance
+            ->expects($this->once())
+            ->method('tokenizeResponse')
+            ->willReturn($token);
+
+        $instance->authenticate($client);
+    }
+
+    public function testTokenizeResponse()
+    {
+        $response = $this->createMock(Sdk\Hal\HalResource::class);
+        $response
+            ->expects($this->once())
+            ->method('getProperty')
+            ->with('access_token')
+            ->willReturn('12345789');
+
+        $instance = new Sdk\Credential\Password('username', 'password');
+        $token = $instance->tokenizeResponse($response);
+
+        $this->assertInstanceOf(Sdk\Credential\Token::class, $token);
+    }
+}

--- a/tests/unit/Credential/TokenTest.php
+++ b/tests/unit/Credential/TokenTest.php
@@ -1,0 +1,27 @@
+<?php
+namespace ShoppingFeed\Sdk\Test\Credential;
+
+use PHPUnit\Framework\TestCase;
+use ShoppingFeed\Sdk;
+
+class TokenTest extends TestCase
+{
+    public function testAuthenticate()
+    {
+        $client = $this->createMock(Sdk\Hal\HalClient::class);
+        $client
+            ->expects($this->once())
+            ->method('withToken')
+            ->willReturn($client);
+
+        $client
+            ->expects($this->once())
+            ->method('request')
+            ->willReturn($this->createMock(Sdk\Hal\HalResource::class));
+
+        $instance = new Sdk\Credential\Token('123456');
+        $session = $instance->authenticate($client);
+
+        $this->assertInstanceOf(Sdk\Api\Session\SessionResource::class, $session);
+    }
+}


### PR DESCRIPTION
**How to test**
1. Checkout the PR
2. Run `docker-compose run sf-php-sdk-dev composer test` at the root of the project.

_If you get an isset error in `ServerHandlerError` you can apply this fix localy https://github.com/shoppingflux/php-sdk/pull/30/files#diff-5a9b41debf506875db35eb932b3445b4R41_