### PR TITLE
Adding unit tests for Api

### DIFF
--- a/src/Api/Catalog/InventoryResource.php
+++ b/src/Api/Catalog/InventoryResource.php
@@ -30,7 +30,9 @@ class InventoryResource extends AbstractResource
     }
 
     /**
-     * @return \DateTimeImmutable
+     * @return \DateTimeImmutable|null
+     *
+     * @throws \Exception
      */
     public function getUpdatedAt()
     {

--- a/src/Api/Session/SessionResource.php
+++ b/src/Api/Session/SessionResource.php
@@ -28,7 +28,7 @@ class SessionResource extends AbstractResource
     public function getStores()
     {
         return new Store\StoreCollection(
-            $this->resource->getResource('store')
+            $this->resource->getResources('store')
         );
     }
 
@@ -41,7 +41,7 @@ class SessionResource extends AbstractResource
     {
         $stores = $this->getStores();
 
-        if (ctype_digit($idOrName)) {
+        if (is_int($idOrName) || ctype_digit($idOrName)) {
             return $stores->getById($idOrName);
         }
 

--- a/src/Api/Store/StoreCollection.php
+++ b/src/Api/Store/StoreCollection.php
@@ -49,7 +49,7 @@ class StoreCollection extends AbstractCollection
      */
     public function select($idOrName)
     {
-        if (ctype_digit($idOrName)) {
+        if (is_int($idOrName) | ctype_digit($idOrName)) {
             return $this->getById($idOrName);
         }
 

--- a/tests/unit/Api/AbstractResourceTest.php
+++ b/tests/unit/Api/AbstractResourceTest.php
@@ -1,0 +1,33 @@
+<?php
+namespace ShoppingFeed\Sdk\Test\Api;
+
+use PHPUnit\Framework\TestCase;
+use ShoppingFeed\Sdk\Hal\HalResource;
+
+abstract class AbstractResourceTest extends TestCase
+{
+    /**
+     * @var HalResource|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $propertyGetter;
+
+    protected $props = [];
+
+    protected function initPropertyGetterTester()
+    {
+        $this->propertyGetter = $this->createMock(HalResource::class);
+        $this->propertyGetter
+            ->expects($this->exactly(count($this->props)))
+            ->method('getProperty')
+            ->with($this->logicalOr(...array_keys($this->props)))
+            ->will($this->returnCallback([$this, 'get']));
+    }
+
+    /**
+     * Simulate getProperty return
+     */
+    public function get($prop)
+    {
+        return $this->props[$prop];
+    }
+}

--- a/tests/unit/Api/Catalog/InventoryDomainTest.php
+++ b/tests/unit/Api/Catalog/InventoryDomainTest.php
@@ -1,0 +1,76 @@
+<?php
+namespace ShoppingFeed\Sdk\Test\Api\Catalog;
+
+use PHPUnit\Framework\TestCase;
+use ShoppingFeed\Sdk;
+
+class InventoryDomainTest extends TestCase
+{
+    public function testOperationExecution()
+    {
+        $link      = $this->createMock(Sdk\Hal\HalLink::class);
+        $operation = $this->createMock(Sdk\Api\Catalog\InventoryUpdate::class);
+        $operation
+            ->expects($this->once())
+            ->method('execute')
+            ->willReturn('OK');
+
+        $instance = new Sdk\Api\Catalog\InventoryDomain($link);
+
+        $this->assertEquals('OK', $instance->execute($operation));
+    }
+
+    public function testGetByReference()
+    {
+        $reference = 'abc213';
+        $link      = $this->createMock(Sdk\Hal\HalLink::class);
+        $resource  = $this->createMock(Sdk\Hal\HalResource::class);
+        $resource
+            ->expects($this->once())
+            ->method('getProperty')
+            ->with('count')
+            ->willReturn(10);
+        $resource
+            ->expects($this->once())
+            ->method('getFirstResource')
+            ->with('inventory')
+            ->willReturn(
+                $this->createMock(Sdk\Hal\HalResource::class)
+            );
+        $link
+            ->expects($this->once())
+            ->method('get')
+            ->with(
+                [],
+                ['query' => ['reference' => $reference]]
+            )
+            ->willReturn($resource);
+
+        $instance = new Sdk\Api\Catalog\InventoryDomain($link);
+
+        $this->assertInstanceOf(Sdk\Api\Catalog\InventoryResource::class, $instance->getByReference($reference));
+    }
+    public function testGetByReferenceNoInvetory()
+    {
+        $reference = 'abc213';
+        $link      = $this->createMock(Sdk\Hal\HalLink::class);
+        $resource  = $this->createMock(Sdk\Hal\HalResource::class);
+        $resource
+            ->expects($this->once())
+            ->method('getProperty')
+            ->with('count')
+            ->willReturn(0);
+        $link
+            ->expects($this->once())
+            ->method('get')
+            ->with(
+                [],
+                ['query' => ['reference' => $reference]]
+            )
+            ->willReturn($resource);
+
+        $instance = new Sdk\Api\Catalog\InventoryDomain($link);
+
+        $this->assertNull($instance->getByReference($reference));
+    }
+}

--- a/tests/unit/Api/Catalog/InventoryResourceTest.php
+++ b/tests/unit/Api/Catalog/InventoryResourceTest.php
@@ -1,17 +1,10 @@
 <?php
 namespace ShoppingFeed\Sdk\Test\Api\Catalog;
 
-use PHPUnit\Framework\TestCase;
-use ShoppingFeed\Sdk\Api\Catalog\InventoryResource;
-use ShoppingFeed\Sdk\Hal\HalResource;
+use ShoppingFeed\Sdk;
 
-class InventoryResourceTest extends TestCase
+class InventoryResourceTest extends Sdk\Test\Api\AbstractResourceTest
 {
-    /**
-     * @var array
-     */
-    private $props = [];
-
     public function setUp()
     {
         $this->props = [
@@ -24,26 +17,13 @@ class InventoryResourceTest extends TestCase
 
     public function testPropertiesGetters()
     {
-        $halResource = $this->createMock(HalResource::class);
-        $halResource
-            ->expects($this->exactly(count($this->props)))
-            ->method('getProperty')
-            ->with($this->logicalOr(...array_keys($this->props)))
-            ->will($this->returnCallback([$this, 'returnGetters']));
+        $this->initPropertyGetterTester();
 
-        $instance = new InventoryResource($halResource);
+        $instance = new Sdk\Api\Catalog\InventoryResource($this->propertyGetter);
 
         $this->assertEquals($this->props['id'], $instance->getId());
         $this->assertEquals($this->props['reference'], $instance->getReference());
         $this->assertEquals($this->props['quantity'], $instance->getQuantity());
         $this->assertEquals(new \DateTimeImmutable($this->props['updatedAt']), $instance->getUpdatedAt());
-    }
-
-    /**
-     * Simulate getProperty return
-     */
-    public function returnGetters($prop)
-    {
-        return $this->props[$prop];
     }
 }

--- a/tests/unit/Api/Catalog/InventoryResourceTest.php
+++ b/tests/unit/Api/Catalog/InventoryResourceTest.php
@@ -1,0 +1,49 @@
+<?php
+namespace ShoppingFeed\Sdk\Test\Api\Catalog;
+
+use PHPUnit\Framework\TestCase;
+use ShoppingFeed\Sdk\Api\Catalog\InventoryResource;
+use ShoppingFeed\Sdk\Hal\HalResource;
+
+class InventoryResourceTest extends TestCase
+{
+    /**
+     * @var array
+     */
+    private $props = [];
+
+    public function setUp()
+    {
+        $this->props = [
+            'id'        => 10,
+            'reference' => 'abc123',
+            'quantity'  => 15,
+            'updatedAt' => 'now',
+        ];
+    }
+
+    public function testPropertiesGetters()
+    {
+        $halResource = $this->createMock(HalResource::class);
+        $halResource
+            ->expects($this->exactly(count($this->props)))
+            ->method('getProperty')
+            ->with($this->logicalOr(...array_keys($this->props)))
+            ->will($this->returnCallback([$this, 'returnGetters']));
+
+        $instance = new InventoryResource($halResource);
+
+        $this->assertEquals($this->props['id'], $instance->getId());
+        $this->assertEquals($this->props['reference'], $instance->getReference());
+        $this->assertEquals($this->props['quantity'], $instance->getQuantity());
+        $this->assertEquals(new \DateTimeImmutable($this->props['updatedAt']), $instance->getUpdatedAt());
+    }
+
+    /**
+     * Simulate getProperty return
+     */
+    public function returnGetters($prop)
+    {
+        return $this->props[$prop];
+    }
+}

--- a/tests/unit/Api/Catalog/InventoryUpdateTest.php
+++ b/tests/unit/Api/Catalog/InventoryUpdateTest.php
@@ -1,0 +1,90 @@
+<?php
+namespace ShoppingFeed\Sdk\Test\Api\Catalog;
+
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\RequestInterface;
+use ShoppingFeed\Sdk;
+
+class InventoryUpdateTest extends TestCase
+{
+    /**
+     * @var array
+     */
+    private $operations = [
+        'abc123'  => 5,
+        'abc1234' => 7,
+        'abc1235' => 8,
+    ];
+
+    public function testConstructWithOperations()
+    {
+        $instance   = new Sdk\Api\Catalog\InventoryUpdate($this->operations);
+        $reflection = new \ReflectionClass($instance);
+        $property   = $reflection->getProperty('operations');
+        $property->setAccessible(true);
+
+        $result = [];
+        foreach ($this->operations as $reference => $quantity) {
+            $result[$reference] = compact('reference', 'quantity');
+        }
+
+        $this->assertEquals($result, $property->getValue($instance));
+
+    }
+
+    public function testAdd()
+    {
+        $instance   = new Sdk\Api\Catalog\InventoryUpdate();
+        $reflection = new \ReflectionClass($instance);
+        $property   = $reflection->getProperty('operations');
+        $property->setAccessible(true);
+
+        $result = [];
+        foreach ($this->operations as $reference => $quantity) {
+            $instance->add($reference, $quantity);
+            $result[$reference] = compact('reference', 'quantity');
+        }
+
+        $this->assertEquals($result, $property->getValue($instance));
+    }
+
+    public function testExecute()
+    {
+        $link = $this->createMock(Sdk\Hal\HalLink::class);
+        $link
+            ->expects($this->once())
+            ->method('createRequest')
+            ->willReturn(
+                $this->createMock(RequestInterface::class)
+            );
+
+        $instance = $this
+            ->getMockBuilder(Sdk\Api\Catalog\InventoryUpdate::class)
+            ->setConstructorArgs([$this->operations])
+            ->setMethods(['getPoolSize'])
+            ->getMock();
+
+        $instance
+            ->expects($this->once())
+            ->method('getPoolSize')
+            ->willReturn(10);
+
+        $link
+            ->expects($this->once())
+            ->method('batchSend')
+            ->with(
+                [$this->createMock(RequestInterface::class)],
+                function (Sdk\Hal\HalResource $resource) use (&$resources) {
+                    array_push($resources, ...$resource->getResources('inventory'));
+                },
+                null,
+                [],
+                10
+            );
+
+        $this->assertInstanceOf(
+            Sdk\Api\Catalog\InventoryCollection::class,
+            $instance->execute($link)
+        );
+    }
+}

--- a/tests/unit/Api/Session/SessionResourceTest.php
+++ b/tests/unit/Api/Session/SessionResourceTest.php
@@ -1,16 +1,10 @@
 <?php
 namespace ShoppingFeed\Sdk\Test\Api\Session;
 
-use PHPUnit\Framework\TestCase;
 use ShoppingFeed\Sdk;
 
-class SessionResourceTest extends TestCase
+class SessionResourceTest extends Sdk\Test\Api\AbstractResourceTest
 {
-    /**
-     * @var array
-     */
-    private $props = [];
-
     /**
      * @var array
      */
@@ -31,25 +25,12 @@ class SessionResourceTest extends TestCase
 
     public function testPropertiesGetters()
     {
-        $halResource = $this->createMock(Sdk\Hal\HalResource::class);
-        $halResource
-            ->expects($this->exactly(count($this->props)))
-            ->method('getProperty')
-            ->with($this->logicalOr(...array_keys($this->props)))
-            ->will($this->returnCallback([$this, 'returnGetters']));
+        $this->initPropertyGetterTester();
 
-        $instance = new Sdk\Api\Session\SessionResource($halResource);
+        $instance = new Sdk\Api\Session\SessionResource($this->propertyGetter);
 
         $this->assertEquals($this->props['email'], $instance->getEmail());
         $this->assertEquals($this->props['login'], $instance->getLogin());
-    }
-
-    /**
-     * Simulate getProperty return
-     */
-    public function returnGetters($prop)
-    {
-        return $this->props[$prop];
     }
 
     public function testGetStores()

--- a/tests/unit/Api/Session/SessionResourceTest.php
+++ b/tests/unit/Api/Session/SessionResourceTest.php
@@ -1,0 +1,131 @@
+<?php
+namespace ShoppingFeed\Sdk\Test\Api\Session;
+
+use PHPUnit\Framework\TestCase;
+use ShoppingFeed\Sdk;
+
+class SessionResourceTest extends TestCase
+{
+    /**
+     * @var array
+     */
+    private $props = [];
+
+    /**
+     * @var array
+     */
+    private $resources = [];
+
+    public function setUp()
+    {
+        $this->props     = [
+            'login' => 'username',
+            'email' => 'user@mail.com',
+        ];
+        $this->resources = [
+            $this->createMock(Sdk\Hal\HalResource::class),
+            $this->createMock(Sdk\Hal\HalResource::class),
+            $this->createMock(Sdk\Hal\HalResource::class),
+        ];
+    }
+
+    public function testPropertiesGetters()
+    {
+        $halResource = $this->createMock(Sdk\Hal\HalResource::class);
+        $halResource
+            ->expects($this->exactly(count($this->props)))
+            ->method('getProperty')
+            ->with($this->logicalOr(...array_keys($this->props)))
+            ->will($this->returnCallback([$this, 'returnGetters']));
+
+        $instance = new Sdk\Api\Session\SessionResource($halResource);
+
+        $this->assertEquals($this->props['email'], $instance->getEmail());
+        $this->assertEquals($this->props['login'], $instance->getLogin());
+    }
+
+    /**
+     * Simulate getProperty return
+     */
+    public function returnGetters($prop)
+    {
+        return $this->props[$prop];
+    }
+
+    public function testGetStores()
+    {
+        $halResource = $this->createMock(Sdk\Hal\HalResource::class);
+        $halResource
+            ->expects($this->once())
+            ->method('getResources')
+            ->with('store')
+            ->willReturn($this->resources);
+
+        $instance = new Sdk\Api\Session\SessionResource($halResource);
+        $stores   = $instance->getStores();
+
+        $this->assertInstanceOf(
+            Sdk\Api\Store\StoreCollection::class,
+            $stores
+        );
+    }
+
+    public function testSelectStore()
+    {
+        $stores   = $this->createMock(Sdk\Api\Store\StoreCollection::class);
+        $instance = $this
+            ->getMockBuilder(Sdk\Api\Session\SessionResource::class)
+            ->setConstructorArgs(
+                [$this->createMock(Sdk\Hal\HalResource::class)]
+            )
+            ->setMethods(['getStores'])
+            ->getMock();
+
+        $instance
+            ->expects($this->exactly(3))
+            ->method('getStores')
+            ->willReturn($stores);
+
+        $stores
+            ->expects($this->exactly(2))
+            ->method('getById')
+            ->willReturn($this->createMock(Sdk\Hal\HalResource::class));
+        $stores
+            ->expects($this->once())
+            ->method('getByName')
+            ->willReturn($this->createMock(Sdk\Hal\HalResource::class));
+
+        $instance->selectStore(10);
+        $instance->selectStore('10');
+        $instance->selectStore('storeName');
+    }
+
+    public function testGetMainStore()
+    {
+        $halResource = $this->createMock(Sdk\Hal\HalResource::class);
+        $halResource
+            ->expects($this->once())
+            ->method('getFirstResource')
+            ->with('store')
+            ->willReturn(
+                $this->createMock(Sdk\Hal\HalResource::class)
+            );
+
+        $instance = new Sdk\Api\Session\SessionResource($halResource);
+
+        $this->assertInstanceOf(Sdk\Api\Store\StoreResource::class, $instance->getMainStore());
+    }
+
+    public function testGetMainStoreNotFound()
+    {
+        $halResource = $this->createMock(Sdk\Hal\HalResource::class);
+        $halResource
+            ->expects($this->once())
+            ->method('getFirstResource')
+            ->with('store');
+
+        $instance = new Sdk\Api\Session\SessionResource($halResource);
+
+        $this->assertNull($instance->getMainStore());
+    }
+}

--- a/tests/unit/Api/Store/StoreCollectionTest.php
+++ b/tests/unit/Api/Store/StoreCollectionTest.php
@@ -1,0 +1,140 @@
+<?php
+namespace ShoppingFeed\Sdk\Test\Api\Store;
+
+use PHPUnit\Framework\TestCase;
+use ShoppingFeed\Sdk;
+
+class StoreCollectionTest extends TestCase
+{
+    private $resourcesData = [
+        ['id' => 123, 'name' => 'abc123'],
+        ['id' => 456, 'name' => 'abc456'],
+        ['id' => 789, 'name' => 'abc789'],
+        ['id' => 159, 'name' => 'abc159'],
+    ];
+
+    public function testGetById()
+    {
+        $instance = new Sdk\Api\Store\StoreCollection($this->getResources('id'));
+
+        $resource = $instance->getById(456);
+
+        $this->assertInstanceOf(Sdk\Api\Store\StoreResource::class, $resource);
+        $this->assertEquals('abc456', $resource->getName());
+        $this->assertEquals(456, $resource->getId());
+    }
+
+    public function testGetByIdWithNoMatch()
+    {
+        $instance = new Sdk\Api\Store\StoreCollection([]);
+        $this->assertNull($instance->getById(456));
+    }
+
+    public function testGetByName()
+    {
+        $instance = new Sdk\Api\Store\StoreCollection($this->getResources('name'));
+
+        $resource = $instance->getByName('abc789');
+
+        $this->assertInstanceOf(Sdk\Api\Store\StoreResource::class, $resource);
+        $this->assertEquals('abc789', $resource->getName());
+        $this->assertEquals(789, $resource->getId());
+    }
+
+    public function testGetByNameWithNoMatch()
+    {
+        $instance = new Sdk\Api\Store\StoreCollection([]);
+        $this->assertNull($instance->getByName('abc789'));
+    }
+
+    public function testSelect()
+    {
+        $instance = $this
+            ->getMockBuilder(Sdk\Api\Store\StoreCollection::class)
+            ->setConstructorArgs([])
+            ->setMethods(['getById', 'getByName'])
+            ->getMock();
+
+        $instance
+            ->expects($this->exactly(2))
+            ->method('getById');
+        $instance
+            ->expects($this->once())
+            ->method('getByName');
+
+        $instance->select(10);
+        $instance->select('10');
+        $instance->select('abc10');
+    }
+
+    /**
+     * Initialize resources
+     *
+     * @param string $type
+     *
+     * @return array
+     */
+    private function getResources($type)
+    {
+        $resources = [];
+        foreach ($this->resourcesData as $data) {
+            $resources[] = $this->getNewResource($data, $type);
+        }
+
+        return $resources;
+    }
+
+    /**
+     * Init new AbstractResource from $data
+     *
+     * @param array  $data
+     * @param string $type
+     *
+     * @return \PHPUnit_Framework_MockObject_MockObject
+     */
+    private function getNewResource($data, $type = 'id')
+    {
+        // Used in tests to assert we have the correct resource
+        $halResource = $this->createMock(Sdk\Hal\HalResource::class);
+        $halResource
+            ->method('getProperty')
+            ->with($this->logicalOr('name', 'id'))
+            ->will($this->returnCallback(
+                function ($type) use ($data) {
+                    return $data[$type];
+                }
+            ));
+
+        $resource = $this->getMockBuilder(Sdk\Api\Store\StoreResource::class)
+            ->setConstructorArgs([$halResource])
+            ->setMethods(['propertyMatch'])
+            ->getMock();
+        $resource
+            ->method('propertyMatch')
+            ->will($this->returnValueMap($this->getResourceMap($data, $type)));
+
+        return $resource;
+    }
+
+    /**
+     * Build map with all data to simulate the check of propertyMatch()
+     *
+     * @param array  $data
+     * @param string $type
+     *
+     * @return array
+     */
+    private function getResourceMap(array $data, $type)
+    {
+        $map = [];
+        foreach ($this->resourcesData as $rData) {
+            $map[] = [
+                $type,
+                $rData[$type],
+                (bool) ($rData[$type] == $data[$type]),
+            ];
+        }
+
+        return $map;
+    }
+}

--- a/tests/unit/Api/Store/StoreResourceTest.php
+++ b/tests/unit/Api/Store/StoreResourceTest.php
@@ -1,0 +1,29 @@
+<?php
+namespace ShoppingFeed\Sdk\Test\Api\Store;
+
+use ShoppingFeed\Sdk;
+
+class StoreResourceTest extends Sdk\Test\Api\AbstractResourceTest
+{
+    public function setUp()
+    {
+        $this->props = [
+            'id'      => 10,
+            'name'    => 'abc123',
+            'country' => 'FR',
+            'status'  => 'active',
+        ];
+    }
+
+    public function testPropertiesGetters()
+    {
+        $this->initPropertyGetterTester();
+
+        $instance = new Sdk\Api\Store\StoreResource($this->propertyGetter);
+
+        $this->assertEquals($this->props['id'], $instance->getId());
+        $this->assertEquals($this->props['name'], $instance->getName());
+        $this->assertEquals($this->props['country'], $instance->getCountryCode());
+        $this->assertTrue($instance->isActive());
+    }
+}

--- a/tests/unit/Api/Store/StoreResourceTest.php
+++ b/tests/unit/Api/Store/StoreResourceTest.php
@@ -26,4 +26,20 @@ class StoreResourceTest extends Sdk\Test\Api\AbstractResourceTest
         $this->assertEquals($this->props['country'], $instance->getCountryCode());
         $this->assertTrue($instance->isActive());
     }
+
+    public function testGetInventory()
+    {
+        $halResource = $this->createMock(Sdk\Hal\HalResource::class);
+        $halResource
+            ->expects($this->once())
+            ->method('getLink')
+            ->with('inventory')
+            ->willReturn(
+                $this->createMock(Sdk\Hal\HalLink::class)
+            );
+
+        $instance = new Sdk\Api\Store\StoreResource($halResource);
+
+        $this->assertInstanceOf(Sdk\Api\Catalog\InventoryDomain::class, $instance->getInventory());
+    }
 }


### PR DESCRIPTION
**How to test**
1. Checkout the PR
2. Run `docker-compose run sf-php-sdk-dev composer test` at the root of the project.

_If you get an isset error in `ServerHandlerError` you can apply this fix localy https://github.com/shoppingflux/php-sdk/pull/30/files#diff-5a9b41debf506875db35eb932b3445b4R41_