### PR TITLE
Removing unnecessary generalisation that break inventory update

### DIFF
--- a/src/Operation/AbstractBulkOperation.php
+++ b/src/Operation/AbstractBulkOperation.php
@@ -100,15 +100,6 @@ abstract class AbstractBulkOperation extends AbstractOperation
             return isset($this->operations[$filter]) ? $this->operations[$filter] : [];
         }
 
-        $operations = (array) $this->operations;
-        // If operations are grouped but no filter is asked we ungrouped operations
-        if (is_null($filter) && ! current($operations) instanceof AbstractOperation) {
-            $operations = [];
-            foreach ($this->operations as $group => $groupedOperations) {
-                $operations = array_merge($operations, $groupedOperations);
-            }
-        }
-
-        return $operations;
+        return (array) $this->operations;
     }
 }

--- a/tests/unit/Operation/AbstractBulkOperationTest.php
+++ b/tests/unit/Operation/AbstractBulkOperationTest.php
@@ -93,16 +93,4 @@ class AbstractBulkOperationTest extends TestCase
 
         $this->assertEquals(count($operations['group1']), $instance->count('group1'));
     }
-
-    public function testCountGroupedOperationWithNoFilter()
-    {
-        $countOperation = 50;
-        $operations     = [];
-        for ($i = 0; $i < $countOperation; $i++) {
-            $operations[$i % 2 ? 'group1' : 'group2'][] = $this->createMock(AbstractOperation::class);
-        };
-        $instance = new BulkOperationMock($operations);
-
-        $this->assertEquals(50, $instance->count());
-    }
 }


### PR DESCRIPTION
When retrieving operation a parsing was done to ungroup operation.
This of no use yet and can be handled at resource api level.
This was breaking inventory update