### PR TITLE
#44 Add order item read & link order with channel resource

### DIFF
--- a/docs/manual/resources/order.md
+++ b/docs/manual/resources/order.md
@@ -6,13 +6,13 @@ Accessing order API can be done from the store.
 
 ```php
 <?php
-/** @var \ShoppingFeed\Sdk\Api\Session\SessionResource $session */
 $orderApi = $session->getMainStore()->getOrderApi();
 ```
 
 ## Retrieve orders
 
 To retrieve order you can use those methods :
+
 - `getAll()` : will retrieve all orders
 - `getPages()` : will retrieve all pages of orders
 - `getPage()` : will retrieve one page of orders
@@ -21,6 +21,7 @@ You can pass pagination and search criteria to `getPage` and `getPages` methods.
 `getAll` only accept filters as it handle pagination automatically.  
   
 Here are the available criteria at your disposal :
+
 - `page` : the page to retrieve or start from
 - `limit` : the number of item per page you want to retrieve (up to a maximum define by the API)
 - `filters` : an array of filters to filter orders by certain attributes
@@ -29,9 +30,8 @@ Here are the available criteria at your disposal :
     partially_shipped
 
 Examples :
+
 ```php
-<?php
-/** @var \ShoppingFeed\Sdk\Api\Order\OrderDomain $orderApi */
 // Criteria used to query order API
 $criteria = [
     'page'    => 1, // first page
@@ -60,16 +60,16 @@ foreach($orderApi->getPage($criteria) as $order) {
 ## Operations
 
 From order API you can then access all available operation :
+
 ```php
-<?php
-/** @var \ShoppingFeed\Sdk\Api\Order\OrderDomain $orderApi */
-$updateOperation = new \ShoppingFeed\Sdk\Api\Order\OrderOperation();
-$updateOperation
+$operation = new \ShoppingFeed\Sdk\Api\Order\OrderOperation();
+$operation
     ->accept('ref3', 'amazon')
     ->refuse('ref4', 'amazon')
     ->ship('ref5', 'amazon')
     ->cancel('ref1', 'amazon');
-$orderApi->execute($updateOperation);
+
+$orderApi->execute($operation);
 ```
 
 Operations allowed on existing order will always be accepted as they are treated asynchronously.  
@@ -78,22 +78,20 @@ that will handle the requested operation.
 With this ticket collection you will be able to find what ticket has been associated with the operation on an order.
 
 ```php
-<?php
-/** @var \ShoppingFeed\Sdk\Api\Order\OrderDomain $orderApi */
-$updateOperation = new \ShoppingFeed\Sdk\Api\Order\OrderOperation();
-/** @var \ShoppingFeed\Sdk\Api\Order\OrderTicketCollection $ticketCollection */
-$updateOperation
+$operation = new \ShoppingFeed\Sdk\Api\Order\OrderOperation();
+$operation
     ->accept('ref3', 'amazon')
     ->refuse('ref4', 'amazon')
     ->ship('ref5', 'amazon')
     ->cancel('ref3', 'amazon');
-$ticketCollection = $orderApi->execute($updateOperation);
+
+$tickets = $orderApi->execute($operation);
 
 // Tickets to follow all acceptance tasks
-$tickets = $ticketCollection->getAccepted();
+$accepted = $ticketCollection->getAccepted();
 
 // Ticket ID to follow 'ref3' cancelling task
-$ticketId = $ticketCollection->getCanceled('ref3')[0]->getId();
+$ticketId = $tickets->getCanceled('ref3')[0]->getId();
 ```
 
 ### Accept
@@ -104,14 +102,14 @@ The accept operation accept 3 parameters :
 3. [optional] `$reason` : The reason of the acceptance (eq: 'Why we accept the order') 
 
 Example :
+
 ```php
-<?php
-/** @var \ShoppingFeed\Sdk\Api\Order\OrderDomain $orderApi */
-$updateOperation = new \ShoppingFeed\Sdk\Api\Order\OrderOperation();
-$updateOperation
+$operation = new \ShoppingFeed\Sdk\Api\Order\OrderOperation();
+$operation
     ->accept('ref1', 'amazon')
     ->accept('ref2', 'amazon', 'Why we accept it');
-$orderApi->execute($updateOperation);
+
+$orderApi->execute($operation);
 ```
 
 ### Cancel
@@ -122,14 +120,14 @@ The cancel operation accept 3 parameters :
 3. [optional] `$reason` : The reason of the cancelling (eq: 'Why we cancel the order') 
 
 Example :
+
 ```php
-<?php
-/** @var \ShoppingFeed\Sdk\Api\Order\OrderDomain $orderApi */
-$updateOperation = new \ShoppingFeed\Sdk\Api\Order\OrderOperation();
-$updateOperation
+$operation = new \ShoppingFeed\Sdk\Api\Order\OrderOperation();
+$operation
     ->cancel('ref1', 'amazon')
     ->cancel('ref2', 'amazon', 'Why we accept it');
-$orderApi->execute($updateOperation);
+
+$orderApi->execute($operation);
 ```
 
 ### Refuse
@@ -140,19 +138,20 @@ The refuse operation accept 3 parameters :
 3. [optional] `$refund` : Item references to refund (eq: `['itemref1', 'itemref2']`) 
 
 Example :
+
 ```php
-<?php
-/** @var \ShoppingFeed\Sdk\Api\Order\OrderDomain $orderApi */
-$updateOperation = new \ShoppingFeed\Sdk\Api\Order\OrderOperation();
-$updateOperation
+$operation = new \ShoppingFeed\Sdk\Api\Order\OrderOperation();
+$operation
     ->refuse('ref1', 'amazon')
     ->refuse('ref2', 'amazon', ['itemref1', 'itemref2']);
-$orderApi->execute($updateOperation);
+
+$orderApi->execute($operation);
 ```
 
 ### Ship
 
 The ship operation accept 3 parameters :
+
 1. [mandatory] `$reference` : Order reference (eg: 'reference1') 
 2. [mandatory] `$channelName` : The channel where the order is from (eg: 'amazon') 
 3. [optional] `$carrier` : The carrier name used for the shipment (eq: 'ups') 
@@ -160,18 +159,19 @@ The ship operation accept 3 parameters :
 3. [optional] `$trackingLink` : Tracking link (eq: 'http://tracking.url/') 
 
 Example :
+
 ```php
-<?php
-/** @var \ShoppingFeed\Sdk\Api\Order\OrderDomain $orderApi */
-$updateOperation = new \ShoppingFeed\Sdk\Api\Order\OrderOperation();
-$updateOperation
+$operation = new \ShoppingFeed\Sdk\Api\Order\OrderOperation();
+$operation
     ->ship('ref1', 'amazon')
     ->ship('ref2', 'amazon', 'ups', '123456789abcdefg', 'http://tracking.url/');
-$orderApi->execute($updateOperation);
+
+$orderApi->execute($operation);
 ```
 ### Acknowledge
 
 To acknowledge the good reception of order :
+
 1. [mandatory] `$reference` : Order reference (eg: 'reference1') 
 2. [mandatory] `$channelName` : The channel where the order is from (eg: 'amazon') 
 3. [mandatory] `$status` : Status of acknowledgment (eq: 'success') 
@@ -179,20 +179,21 @@ To acknowledge the good reception of order :
 5. [optional] `$message` : Acknowledge message  (eq: 'Order well acknowledge') 
 
 Example :
+
 ```php
-<?php
-/** @var \ShoppingFeed\Sdk\Api\Order\OrderDomain $orderApi */
-$updateOperation = new \ShoppingFeed\Sdk\Api\Order\OrderOperation();
-$updateOperation
+$operation = new \ShoppingFeed\Sdk\Api\Order\OrderOperation();
+$operation
     ->acknowledge('reference1', 'amazon', 'success', 'store-reference')
     ->acknowledge('reference1', 'amazon', 'error', 'store-reference')
     ->acknowledge('reference1', 'amazon', 'error', 'store-reference', 'Order well acknowledged');
-$orderApi->execute($updateOperation);
+
+$orderApi->execute($operation);
 ```
 
 ### Unacknowledge
 
 To unacknowledge the good reception of order :
+
 1. [mandatory] `$reference` : Order reference (eg: 'reference1') 
 2. [mandatory] `$channelName` : The channel where the order is from (eg: 'amazon') 
 3. [mandatory] `$status` : Status of unacknowledgment (eq: 'success') 
@@ -200,13 +201,13 @@ To unacknowledge the good reception of order :
 5. [optional] `$message` : Unacknowledge message  (eq: 'Order well unacknowledge') 
 
 Example :
+
 ```php
-<?php
-/** @var \ShoppingFeed\Sdk\Api\Order\OrderDomain $orderApi */
-$updateOperation = new \ShoppingFeed\Sdk\Api\Order\OrderOperation();
-$updateOperation
+$operation = new \ShoppingFeed\Sdk\Api\Order\OrderOperation();
+$operation
     ->unacknowledge('reference1', 'amazon', 'success', 'store-reference')
     ->unacknowledge('reference1', 'amazon', 'error', 'store-reference')
     ->unacknowledge('reference1', 'amazon', 'error', 'store-reference', 'Order well unacknowledged');
-$orderApi->execute($updateOperation);
+
+$orderApi->execute($operation);
 ```

--- a/src/Api/Channel/ChannelResource.php
+++ b/src/Api/Channel/ChannelResource.php
@@ -1,0 +1,59 @@
+<?php
+namespace ShoppingFeed\Sdk\Api\Channel;
+
+use ShoppingFeed\Sdk\Resource\AbstractResource;
+
+class ChannelResource extends AbstractResource
+{
+    /**
+     * The resource id
+     *
+     * @return int
+     */
+    public function getId()
+    {
+        return (int) $this->getProperty('id');
+    }
+
+    /**
+     * The channel name
+     *
+     * @return string
+     */
+    public function getName()
+    {
+        return (string) $this->getProperty('name');
+    }
+
+    /**
+     * @return string The channel's logo url
+     */
+    public function getLogoUrl()
+    {
+        return $this->resource->getLink('image')->getHref();
+    }
+
+    /**
+     * @return string The channel type: marketplace, shopbot...etc
+     */
+    public function getType()
+    {
+        return (string) $this->getProperty('type', true);
+    }
+
+    /**
+     * @return string The channel market segment position
+     */
+    public function getSegment()
+    {
+        return (string) $this->getProperty('segment', true);
+    }
+
+    /**
+     * @return array A list of country codes where the channel is present
+     */
+    public function getCountryCodes()
+    {
+        return (array) $this->getProperty('countries', true);
+    }
+}

--- a/src/Api/Order/OrderDomain.php
+++ b/src/Api/Order/OrderDomain.php
@@ -7,6 +7,8 @@ use ShoppingFeed\Sdk\Resource\AbstractDomainResource;
 /**
  * @method ApiOrder\OrderResource[] getIterator()
  * @method ApiOrder\OrderResource[] getAll($criteria = [])
+ * @method ApiOrder\OrderResource[] getPage(array $criteria = [])
+ * @method ApiOrder\OrderResource[] getPages(array $criteria = [])
  */
 class OrderDomain extends AbstractDomainResource
 {

--- a/src/Api/Order/OrderItem.php
+++ b/src/Api/Order/OrderItem.php
@@ -6,8 +6,19 @@ namespace ShoppingFeed\Sdk\Api\Order;
  */
 class OrderItem
 {
+    /**
+     * @var string
+     */
     private $reference;
+
+    /**
+     * @var int
+     */
     private $quantity;
+
+    /**
+     * @var float
+     */
     private $unitPrice;
 
     /**

--- a/src/Api/Order/OrderItem.php
+++ b/src/Api/Order/OrderItem.php
@@ -53,4 +53,16 @@ class OrderItem
     {
         return $this->getUnitPrice() * $this->getQuantity();
     }
+
+    /**
+     * @return array
+     */
+    public function toArray()
+    {
+        return [
+            'reference' => $this->getReference(),
+            'quantity'  => $this->getQuantity(),
+            'price'     => $this->getUnitPrice()
+        ];
+    }
 }

--- a/src/Api/Order/OrderItem.php
+++ b/src/Api/Order/OrderItem.php
@@ -1,0 +1,56 @@
+<?php
+namespace ShoppingFeed\Sdk\Api\Order;
+
+/**
+ * Class that represents the cart items of the order.
+ */
+class OrderItem
+{
+    private $reference;
+    private $quantity;
+    private $unitPrice;
+
+    /**
+     * @param string $reference The product's reference
+     * @param int    $quantity  Number product's occurrence in cart
+     * @param float  $price     The price for a single unit of the reference (not price * quantity)
+     */
+    public function __construct($reference, $quantity, $price)
+    {
+        $this->reference = $reference;
+        $this->quantity  = $quantity;
+        $this->unitPrice = $price;
+    }
+
+    /**
+     * @return string
+     */
+    public function getReference()
+    {
+        return $this->reference;
+    }
+
+    /**
+     * @return int
+     */
+    public function getQuantity()
+    {
+        return $this->quantity;
+    }
+
+    /**
+     * @return float
+     */
+    public function getUnitPrice()
+    {
+        return $this->unitPrice;
+    }
+
+    /**
+     * @return float|int
+     */
+    public function getTotalPrice()
+    {
+        return $this->getUnitPrice() * $this->getQuantity();
+    }
+}

--- a/src/Api/Order/OrderItemCollection.php
+++ b/src/Api/Order/OrderItemCollection.php
@@ -1,0 +1,48 @@
+<?php
+namespace ShoppingFeed\Sdk\Api\Order;
+
+use Traversable;
+
+class OrderItemCollection implements \Countable, \IteratorAggregate
+{
+    /**
+     * @var array
+     */
+    private $items = [];
+
+    /**
+     * @param array $items  Collection of untyped order items
+     *
+     * @return OrderItemCollection  A new instance of self, holding relevant items
+     */
+    public static function fromProperties(array $items)
+    {
+        $instance = new self;
+        foreach ($items as $item) {
+            $instance->add(new OrderItem($item['reference'], $item['quantity'], $item['price']));
+        }
+
+        return $instance;
+    }
+
+    public function count()
+    {
+        return count($this->items);
+    }
+
+    /**
+     * @return \ArrayIterator|OrderItem[]
+     */
+    public function getIterator()
+    {
+        return new \ArrayIterator($this->items);
+    }
+
+    /**
+     * @param OrderItem $item
+     */
+    private function add(OrderItem $item)
+    {
+        $this->items[] = $item;
+    }
+}

--- a/src/Api/Order/OrderItemCollection.php
+++ b/src/Api/Order/OrderItemCollection.php
@@ -39,6 +39,16 @@ class OrderItemCollection implements \Countable, \IteratorAggregate
     }
 
     /**
+     * @return array
+     */
+    public function toArray()
+    {
+        return array_map(function(OrderItem $item) {
+            return $item->toArray();
+        }, $this->items);
+    }
+
+    /**
      * @param OrderItem $item
      */
     private function add(OrderItem $item)

--- a/src/Api/Order/OrderResource.php
+++ b/src/Api/Order/OrderResource.php
@@ -42,17 +42,15 @@ class OrderResource extends AbstractResource
      */
     public function getAcknowledgedAt()
     {
-        $dateValue = $this->getProperty('acknowledgedAt');
-        return date_create_immutable(is_null($dateValue) ? 'now' : $dateValue);
+        return $this->getPropertyDatetime('acknowledgedAt');
     }
 
     /**
      * @return null|\DateTimeImmutable
      */
-    public function getUpdateddAt()
+    public function getUpdatedAt()
     {
-        $dateValue = $this->getProperty('updatedAt');
-        return date_create_immutable(is_null($dateValue) ? 'now' : $dateValue);
+        return $this->getPropertyDatetime('updatedAt');
     }
 
     /**
@@ -60,7 +58,7 @@ class OrderResource extends AbstractResource
      */
     public function getCreatedAt()
     {
-        return date_create_immutable($this->getProperty('createdAt'));
+        return $this->getPropertyDatetime('createdAt');
     }
 
     /**
@@ -93,5 +91,18 @@ class OrderResource extends AbstractResource
     public function getShipment()
     {
         return $this->getProperty('shipment');
+    }
+
+    /**
+     * Fetch order items details.
+     * The resource has to be loaded to access to items collection
+     */
+    public function getItems()
+    {
+        $this->initialize();
+
+        return OrderItemCollection::fromProperties(
+            $this->getProperty('items') ?: []
+        );
     }
 }

--- a/src/Api/Order/OrderResource.php
+++ b/src/Api/Order/OrderResource.php
@@ -1,6 +1,7 @@
 <?php
 namespace ShoppingFeed\Sdk\Api\Order;
 
+use ShoppingFeed\Sdk\Api\Channel\ChannelResource;
 use ShoppingFeed\Sdk\Resource\AbstractResource;
 
 class OrderResource extends AbstractResource
@@ -99,10 +100,18 @@ class OrderResource extends AbstractResource
      */
     public function getItems()
     {
-        $this->initialize();
-
         return OrderItemCollection::fromProperties(
-            $this->getProperty('items') ?: []
+            $this->getProperty('items', true) ?: []
+        );
+    }
+
+    /**
+     * @return ChannelResource A partial representation of the channel resource
+     */
+    public function getChannel()
+    {
+        return new ChannelResource(
+            $this->resource->getFirstResource('channel')
         );
     }
 }

--- a/src/Resource/AbstractDomainResource.php
+++ b/src/Resource/AbstractDomainResource.php
@@ -35,6 +35,7 @@ abstract class AbstractDomainResource
     public function getPage(array $criteria = [])
     {
         $criteria = new PaginationCriteria($criteria);
+
         return $this->createPaginator($criteria);
     }
 

--- a/src/Resource/AbstractResource.php
+++ b/src/Resource/AbstractResource.php
@@ -55,12 +55,18 @@ abstract class AbstractResource implements \JsonSerializable
     }
 
     /**
-     * @param string $property
+     * @param string $property   The property name
+     * @param bool   $initialize Indicates if the resource must be fetched from server
+     *                           in order to access to this property (when no present in partial representation)
      *
      * @return mixed|null
      */
-    protected function getProperty($property)
+    protected function getProperty($property, $initialize = false)
     {
+        if (true === $initialize) {
+            $this->initialize();
+        }
+
         return $this->resource->getProperty($property);
     }
 

--- a/src/Resource/AbstractResource.php
+++ b/src/Resource/AbstractResource.php
@@ -57,13 +57,15 @@ abstract class AbstractResource implements \JsonSerializable
     /**
      * @param string $property   The property name
      * @param bool   $initialize Indicates if the resource must be fetched from server
-     *                           in order to access to this property (when no present in partial representation)
+     *                           in order to access to this property (when not present in partial representation)
+     *                           The property absence in the current representation is mandatory to pull data
+     *                           from remote API
      *
      * @return mixed|null
      */
     protected function getProperty($property, $initialize = false)
     {
-        if (true === $initialize) {
+        if (true === $initialize && ! $this->resource->hasProperty($property)) {
             $this->initialize();
         }
 

--- a/tests/unit/Api/AbstractResourceTest.php
+++ b/tests/unit/Api/AbstractResourceTest.php
@@ -9,25 +9,28 @@ abstract class AbstractResourceTest extends TestCase
     /**
      * @var HalResource|\PHPUnit_Framework_MockObject_MockObject
      */
-    protected $propertyGetter;
+    protected $halResource;
 
     protected $props = [];
 
-    protected function initPropertyGetterTester()
+    protected function initHalResourceProperties(array $props = [])
     {
-        $this->propertyGetter = $this->createMock(HalResource::class);
-        $this->propertyGetter
-            ->expects($this->exactly(count($this->props)))
-            ->method('getProperty')
-            ->with($this->logicalOr(...array_keys($this->props)))
-            ->will($this->returnCallback([$this, 'get']));
-    }
+        if (! $props) {
+            $props = $this->props;
+        }
 
-    /**
-     * Simulate getProperty return
-     */
-    public function get($prop)
-    {
-        return $this->props[$prop];
+        $this->halResource = $this->createMock(HalResource::class);
+        $this->halResource
+            ->expects($this->exactly(count($props)))
+            ->method('getProperty')
+            ->with($this->logicalOr(...array_keys($props)))
+            ->will($this->returnCallback(function($prop) use($props) {
+                return $props[$prop];
+            }));
+
+        // supports initialization by default
+        $this->halResource
+            ->method('get')
+            ->willReturnSelf();
     }
 }

--- a/tests/unit/Api/Catalog/InventoryResourceTest.php
+++ b/tests/unit/Api/Catalog/InventoryResourceTest.php
@@ -17,9 +17,9 @@ class InventoryResourceTest extends Sdk\Test\Api\AbstractResourceTest
 
     public function testPropertiesGetters()
     {
-        $this->initPropertyGetterTester();
+        $this->initHalResourceProperties();
 
-        $instance = new Sdk\Api\Catalog\InventoryResource($this->propertyGetter);
+        $instance = new Sdk\Api\Catalog\InventoryResource($this->halResource);
 
         $this->assertEquals($this->props['id'], $instance->getId());
         $this->assertEquals($this->props['reference'], $instance->getReference());

--- a/tests/unit/Api/Channel/ChannelResourceTest.php
+++ b/tests/unit/Api/Channel/ChannelResourceTest.php
@@ -1,0 +1,52 @@
+<?php
+namespace ShoppingFeed\Sdk\Api\Channel;
+
+use ShoppingFeed\Sdk\Hal\HalLink;
+use ShoppingFeed\Sdk\Test\Api\AbstractResourceTest;
+
+class ChannelResourceTest extends AbstractResourceTest
+{
+    public function testPartialAccessors()
+    {
+        //Set up regular properties
+        $this->initHalResourceProperties([
+            'id'   => 1,
+            'name' => 'toto'
+        ]);
+
+        // Setup image link
+        $link = $this->createMock(HalLink::class);
+        $link
+            ->method('getHref')
+            ->willReturn('http://toto.jpg');
+
+        $this->halResource
+            ->method('getLink')
+            ->with('image')
+            ->willReturn($link);
+
+        // Expectations time
+        $instance = new ChannelResource($this->halResource);
+
+        $this->assertSame(1, $instance->getId());
+        $this->assertSame('toto', $instance->getName());
+        $this->assertSame('http://toto.jpg', $instance->getLogoUrl());
+    }
+
+    public function testOtherAccessors()
+    {
+        //Set up regular properties
+        $this->initHalResourceProperties($props = [
+            'segment'   => 'shoes',
+            'countries' => ['FR', 'US'],
+            'type'      => 'marketplace'
+        ]);
+
+        // Expectations time
+        $instance = new ChannelResource($this->halResource);
+        $this->assertSame($props['segment'], $instance->getSegment());
+        $this->assertSame($props['countries'], $instance->getCountryCodes());
+        $this->assertSame($props['type'], $instance->getType());
+    }
+}
+

--- a/tests/unit/Api/Order/OrderItemCollectionTest.php
+++ b/tests/unit/Api/Order/OrderItemCollectionTest.php
@@ -49,4 +49,10 @@ class OrderItemCollectionTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals($items[1], $secondOne);
     }
+
+    public function testCollectionCanBeRevertedBackToArray()
+    {
+        $instance = OrderItemCollection::fromProperties($this->items);
+        $this->assertEquals($this->items, $instance->toArray());
+    }
 }

--- a/tests/unit/Api/Order/OrderItemCollectionTest.php
+++ b/tests/unit/Api/Order/OrderItemCollectionTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace ShoppingFeed\Sdk\Api\Order;
+
+class OrderItemCollectionTest extends \PHPUnit_Framework_TestCase
+{
+    private $items = [
+        [
+            'reference' => 'a',
+            'quantity'  => 1,
+            'price'     => 2
+        ],
+        [
+            'reference' => 'b',
+            'quantity'  => 2,
+            'price'     => 3
+        ]
+    ];
+
+    public function testCreateCollectionFromArrayOfRemoteProperties()
+    {
+        $instance = OrderItemCollection::fromProperties($this->items);
+
+        self::assertInstanceOf(OrderItemCollection::class, $instance);
+        $this->assertCount(2, $instance);
+
+        $items = $instance->getIterator()->getArrayCopy();
+        $this->assertContainsOnlyInstancesOf(OrderItem::class, $items);
+    }
+
+    public function testItemsAreWellConstructedFromArray()
+    {
+        $instance = OrderItemCollection::fromProperties($this->items);
+        $items    = $instance->getIterator()->getArrayCopy();
+
+        $firstOne = new OrderItem(
+            $this->items[0]['reference'],
+            $this->items[0]['quantity'],
+            $this->items[0]['price']
+        );
+
+        $this->assertEquals($items[0], $firstOne);
+
+        $secondOne = new OrderItem(
+            $this->items[1]['reference'],
+            $this->items[1]['quantity'],
+            $this->items[1]['price']
+        );
+
+        $this->assertEquals($items[1], $secondOne);
+    }
+}

--- a/tests/unit/Api/Order/OrderItemTest.php
+++ b/tests/unit/Api/Order/OrderItemTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace ShoppingFeed\Sdk\Api\Order;
+
+class OrderItemTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var OrderItem
+     */
+    private $instance;
+
+    public function setUp()
+    {
+        $this->instance = new OrderItem('a', 2, 9.99);
+    }
+
+    public function testGetReference()
+    {
+        $this->assertSame('a', $this->instance->getReference(), 'Reference is the first constructor arg');
+    }
+
+    public function testGetQuantity()
+    {
+        $this->assertSame(2, $this->instance->getQuantity(), 'Quantity is the second constructor arg');
+    }
+
+    public function testGetUnitPrice()
+    {
+        $this->assertSame(9.99, $this->instance->getUnitPrice(), 'Unit Price is the last constructor arg');
+    }
+
+    public function testGetTotalPriceWithComputeRowPrice()
+    {
+        $this->assertSame(19.98, $this->instance->getTotalPrice());
+    }
+}
+

--- a/tests/unit/Api/Order/OrderResourceTest.php
+++ b/tests/unit/Api/Order/OrderResourceTest.php
@@ -55,9 +55,9 @@ class OrderResourceTest extends Sdk\Test\Api\AbstractResourceTest
 
     public function testPropertiesGetters()
     {
-        $this->initPropertyGetterTester();
+        $this->initHalResourceProperties();
 
-        $instance = new Sdk\Api\Order\OrderResource($this->propertyGetter);
+        $instance = new Sdk\Api\Order\OrderResource($this->halResource);
 
         $this->assertEquals($this->props['id'], $instance->getId());
         $this->assertEquals($this->props['reference'], $instance->getReference());
@@ -78,9 +78,9 @@ class OrderResourceTest extends Sdk\Test\Api\AbstractResourceTest
             'updatedAt'      => null,
             'acknowledgedAt' => null,
         ];
-        $this->initPropertyGetterTester();
+        $this->initHalResourceProperties();
 
-        $instance = new Sdk\Api\Order\OrderResource($this->propertyGetter);
+        $instance = new Sdk\Api\Order\OrderResource($this->halResource);
 
         $this->assertNull($instance->getUpdatedAt());
         $this->assertNull($instance->getAcknowledgedAt());
@@ -88,7 +88,7 @@ class OrderResourceTest extends Sdk\Test\Api\AbstractResourceTest
 
     public function testGetItemsLoadOrderEntity()
     {
-        $this->props = [
+        $this->initHalResourceProperties([
             'items' => [
                 [
                     'reference' => 'a',
@@ -96,17 +96,9 @@ class OrderResourceTest extends Sdk\Test\Api\AbstractResourceTest
                     'quantity'  => 1
                 ]
             ]
-        ];
+        ]);
 
-        $this->initPropertyGetterTester();
-
-        // Check that initialize call is performed
-        $this->propertyGetter
-            ->expects($this->once())
-            ->method('get')
-            ->willReturnSelf();
-
-        $instance = new Sdk\Api\Order\OrderResource($this->propertyGetter);
+        $instance = new Sdk\Api\Order\OrderResource($this->halResource);
         $items    = $instance->getItems();
 
         $this->assertInstanceOf(Sdk\Api\Order\OrderItemCollection::class, $items);

--- a/tests/unit/Api/Order/OrderResourceTest.php
+++ b/tests/unit/Api/Order/OrderResourceTest.php
@@ -68,7 +68,7 @@ class OrderResourceTest extends Sdk\Test\Api\AbstractResourceTest
         $this->assertEquals($this->props['shippingAddress'], $instance->getShippingAddress());
         $this->assertEquals($this->props['billingAddress'], $instance->getBillingAddress());
         $this->assertEquals(date_create_immutable($this->props['createdAt']), $instance->getCreatedAt());
-        $this->assertEquals(date_create_immutable($this->props['updatedAt']), $instance->getUpdateddAt());
+        $this->assertEquals(date_create_immutable($this->props['updatedAt']), $instance->getUpdatedAt());
         $this->assertEquals(date_create_immutable($this->props['acknowledgedAt']), $instance->getAcknowledgedAt());
     }
 
@@ -82,7 +82,34 @@ class OrderResourceTest extends Sdk\Test\Api\AbstractResourceTest
 
         $instance = new Sdk\Api\Order\OrderResource($this->propertyGetter);
 
-        $this->assertInstanceOf(\DateTimeImmutable::class, $instance->getUpdateddAt());
-        $this->assertInstanceOf(\DateTimeImmutable::class, $instance->getAcknowledgedAt());
+        $this->assertNull($instance->getUpdatedAt());
+        $this->assertNull($instance->getAcknowledgedAt());
+    }
+
+    public function testGetItemsLoadOrderEntity()
+    {
+        $this->props = [
+            'items' => [
+                [
+                    'reference' => 'a',
+                    'price'     => 9.99,
+                    'quantity'  => 1
+                ]
+            ]
+        ];
+
+        $this->initPropertyGetterTester();
+
+        // Check that initialize call is performed
+        $this->propertyGetter
+            ->expects($this->once())
+            ->method('get')
+            ->willReturnSelf();
+
+        $instance = new Sdk\Api\Order\OrderResource($this->propertyGetter);
+        $items    = $instance->getItems();
+
+        $this->assertInstanceOf(Sdk\Api\Order\OrderItemCollection::class, $items);
+        $this->assertCount(1, $items, 'item is in collection');
     }
 }

--- a/tests/unit/Api/Session/SessionResourceTest.php
+++ b/tests/unit/Api/Session/SessionResourceTest.php
@@ -26,9 +26,9 @@ class SessionResourceTest extends Sdk\Test\Api\AbstractResourceTest
 
     public function testPropertiesGetters()
     {
-        $this->initPropertyGetterTester();
+        $this->initHalResourceProperties();
 
-        $instance = new Sdk\Api\Session\SessionResource($this->propertyGetter);
+        $instance = new Sdk\Api\Session\SessionResource($this->halResource);
 
         $this->assertEquals($this->props['email'], $instance->getEmail());
         $this->assertEquals($this->props['login'], $instance->getLogin());

--- a/tests/unit/Api/Store/StoreResourceTest.php
+++ b/tests/unit/Api/Store/StoreResourceTest.php
@@ -17,9 +17,9 @@ class StoreResourceTest extends Sdk\Test\Api\AbstractResourceTest
 
     public function testPropertiesGetters()
     {
-        $this->initPropertyGetterTester();
+        $this->initHalResourceProperties();
 
-        $instance = new Sdk\Api\Store\StoreResource($this->propertyGetter);
+        $instance = new Sdk\Api\Store\StoreResource($this->halResource);
 
         $this->assertEquals($this->props['id'], $instance->getId());
         $this->assertEquals($this->props['name'], $instance->getName());

--- a/tests/unit/Api/Task/TicketResourceTest.php
+++ b/tests/unit/Api/Task/TicketResourceTest.php
@@ -15,9 +15,9 @@ class TicketResourceTest extends AbstractResourceTest
 
     public function testGetproperty()
     {
-        $this->initPropertyGetterTester();
+        $this->initHalResourceProperties();
 
-        $instance = new TicketResource($this->propertyGetter);
+        $instance = new TicketResource($this->halResource);
 
         $this->assertEquals($this->props['id'], $instance->getId());
     }

--- a/tests/unit/Resource/ResourceMock.php
+++ b/tests/unit/Resource/ResourceMock.php
@@ -10,9 +10,9 @@ use ShoppingFeed\Sdk\Resource\AbstractResource;
  */
 class ResourceMock extends AbstractResource
 {
-    public function getProperty($property)
+    public function getProperty($property, $initialize = false)
     {
-        return parent::getProperty($property);
+        return parent::getProperty($property, $initialize);
     }
 
     public function propertyMatch($property, $value)


### PR DESCRIPTION
### Link to the issue
#44 

### Reason for this PR

- Order details were not accessible from the OrderResource object
- Channel info were not accessible from the OrderResource object

### What does the PR do

Implements accessors for both

### Unrelated changes

The `AbstractResource::getProperty()` method now accept a second argument, which indicates if the resource must loaded from the server to access to that property. 

An usage example is here, where orders items are only provided when fetching a single resource:

https://github.com/shoppingflux/php-sdk/pull/47/files#diff-d7931d116e86a29bdd1e9ae70a77fcaaR104

Note that server request is only performed once, and not on every property access demand.

### How to test

The following script will loop agains orders and print items / channel data : 

```php
$store    = $session->getMainStore();
$orders  = $store->getOrderApi()->getPage(['limit' => 10]);

foreach ($orders as $order) {
    print_r($order->getItems()->toArray());
    print_r($order->getChannel()->toArray());
}
```



