### PR TITLE
#17 - adding filter order by tag doc

### DIFF
--- a/docs/manual/resources/order.md
+++ b/docs/manual/resources/order.md
@@ -28,6 +28,7 @@ Here are the available criteria at your disposal :
     - `status` : filter order by their status, multiple status are allowed. Status available are : created, 
     waiting_store_acceptance, refused, waiting_shipment, shipped, cancelled, refunded, partially_refunded, 
     partially_shipped
+    - `tag` : retrieve order linked to the requested tag
 
 Examples :
 
@@ -38,6 +39,7 @@ $criteria = [
     'limit'   => 20, // 20 order per page
     'filters' => [
         'status' => ['shipped', 'cancelled'] // we only want order with shipped or cancelled status
+        'tag'    => 'test'                   // we only want order linked to 'test' tag
     ]
 ];
 


### PR DESCRIPTION
### Link to the issue
https://github.com/shoppingflux/php-sdk/issues/17

### What does the PR do
Adding tag filtering on order collection resolve #17  

### How to test
Only order with the request tag should be listed
```php
$criterias      = [
    'filters' => [
        'tag' => '[TAG TO FILTER]',
    ],
];
foreach ($orderDomain->getPage($criterias) as $order) {
    echo $order->getReference();
}
```


