### PR TITLE
Fix order operation acknowledge date

### DIFF
--- a/src/Api/Order/OrderOperation.php
+++ b/src/Api/Order/OrderOperation.php
@@ -147,7 +147,7 @@ class OrderOperation extends Operation\AbstractBulkOperation
      */
     public function acknowledge($reference, $channelName, $status, $storeReference, $message = '')
     {
-        $acknowledgedAt = (new \DateTimeImmutable())->format(\DateTime::ISO8601);
+        $acknowledgedAt = (new \DateTimeImmutable())->format('c');
 
         $this->addOperation(
             $reference,
@@ -175,7 +175,7 @@ class OrderOperation extends Operation\AbstractBulkOperation
      */
     public function unacknowledge($reference, $channelName, $status, $storeReference, $message = '')
     {
-        $acknowledgedAt = (new \DateTimeImmutable())->format(\DateTime::ISO8601);
+        $acknowledgedAt = (new \DateTimeImmutable())->format('c');
 
         $this->addOperation(
             $reference,

--- a/src/Api/Order/OrderOperation.php
+++ b/src/Api/Order/OrderOperation.php
@@ -145,9 +145,9 @@ class OrderOperation extends Operation\AbstractBulkOperation
      * @throws Order\Exception\UnexpectedTypeException
      * @throws \Exception
      */
-    public function acknowledge($reference, $channelName, $status, $storeReference, $message = '')
+    public function acknowledge($reference, $channelName, $storeReference = '', $status = 'success', $message = '')
     {
-        $acknowledgedAt = date('c');
+        $acknowledgedAt = date_create()->format('c');
 
         $this->addOperation(
             $reference,
@@ -162,26 +162,20 @@ class OrderOperation extends Operation\AbstractBulkOperation
     /**
      * Unacknowledge order reception
      *
-     * @param string $reference
-     * @param string $channelName
-     * @param string $status
-     * @param string $storeReference
-     * @param string $message
+     * @param string $reference     The channel's order reference
+     * @param string $channelName   The channel's name
      *
      * @return OrderOperation
      *
      * @throws Order\Exception\UnexpectedTypeException
      * @throws \Exception
      */
-    public function unacknowledge($reference, $channelName, $status, $storeReference, $message = '')
+    public function unacknowledge($reference, $channelName)
     {
-        $acknowledgedAt = date('c');
-
         $this->addOperation(
             $reference,
             $channelName,
-            OrderOperation::TYPE_UNACKNOWLEDGE,
-            compact('status', 'storeReference', 'acknowledgedAt', 'message')
+            OrderOperation::TYPE_UNACKNOWLEDGE
         );
 
         return $this;

--- a/src/Api/Order/OrderOperation.php
+++ b/src/Api/Order/OrderOperation.php
@@ -147,7 +147,7 @@ class OrderOperation extends Operation\AbstractBulkOperation
      */
     public function acknowledge($reference, $channelName, $status, $storeReference, $message = '')
     {
-        $acknowledgedAt = (new \DateTimeImmutable())->format('c');
+        $acknowledgedAt = date('c');
 
         $this->addOperation(
             $reference,
@@ -175,7 +175,7 @@ class OrderOperation extends Operation\AbstractBulkOperation
      */
     public function unacknowledge($reference, $channelName, $status, $storeReference, $message = '')
     {
-        $acknowledgedAt = (new \DateTimeImmutable())->format('c');
+        $acknowledgedAt = date('c');
 
         $this->addOperation(
             $reference,

--- a/src/Api/Order/OrderOperation.php
+++ b/src/Api/Order/OrderOperation.php
@@ -147,7 +147,8 @@ class OrderOperation extends Operation\AbstractBulkOperation
      */
     public function acknowledge($reference, $channelName, $status, $storeReference, $message = '')
     {
-        $acknowledgedAt = new \DateTimeImmutable('now');
+        $acknowledgedAt = (new \DateTimeImmutable())->format(\DateTime::ISO8601);
+
         $this->addOperation(
             $reference,
             $channelName,
@@ -174,7 +175,8 @@ class OrderOperation extends Operation\AbstractBulkOperation
      */
     public function unacknowledge($reference, $channelName, $status, $storeReference, $message = '')
     {
-        $acknowledgedAt = new \DateTimeImmutable('now');
+        $acknowledgedAt = (new \DateTimeImmutable())->format(\DateTime::ISO8601);
+
         $this->addOperation(
             $reference,
             $channelName,

--- a/tests/unit/Api/Order/OrderOperationTest.php
+++ b/tests/unit/Api/Order/OrderOperationTest.php
@@ -198,7 +198,7 @@ class OrderOperationTest extends TestCase
                         return $param['status'] === $data[2]
                                && $param['storeReference'] === $data[3]
                                && $param['message'] === $data[4]
-                               && $param['acknowledgedAt'] instanceof \DateTimeImmutable;
+                               && !empty($param['acknowledgedAt']);
                     }
                 )
             );
@@ -238,7 +238,7 @@ class OrderOperationTest extends TestCase
                         return $param['status'] === $data[2]
                                && $param['storeReference'] === $data[3]
                                && $param['message'] === $data[4]
-                               && $param['acknowledgedAt'] instanceof \DateTimeImmutable;
+                               && !empty($param['acknowledgedAt']);
                     }
                 )
             );

--- a/tests/unit/Api/Order/OrderOperationTest.php
+++ b/tests/unit/Api/Order/OrderOperationTest.php
@@ -176,8 +176,8 @@ class OrderOperationTest extends TestCase
         $data = [
             'ref1',
             'amazon',
-            'success',
             '123654abc',
+            'success',
             'Acknowledged',
         ];
 
@@ -195,9 +195,9 @@ class OrderOperationTest extends TestCase
                 Sdk\Api\Order\OrderOperation::TYPE_ACKNOWLEDGE,
                 new \PHPUnit_Framework_Constraint_Callback(
                     function ($param) use ($data) {
-                        return $param['status'] === $data[2]
-                               && $param['storeReference'] === $data[3]
-                               && $param['message'] === $data[4]
+                        return $param['status'] === 'success'
+                               && $param['storeReference'] === '123654abc'
+                               && $param['message'] === 'Acknowledged'
                                && !empty($param['acknowledgedAt']);
                     }
                 )
@@ -214,11 +214,9 @@ class OrderOperationTest extends TestCase
      */
     public function testUnacknowledgeOperation()
     {
-        $data     = [
+        $data = [
             'ref2',
             'amazon2',
-            'success2',
-            '123654abcd',
             'Unacknowledged',
         ];
         $instance = $this
@@ -232,15 +230,7 @@ class OrderOperationTest extends TestCase
             ->with(
                 'ref2',
                 'amazon2',
-                Sdk\Api\Order\OrderOperation::TYPE_UNACKNOWLEDGE,
-                new \PHPUnit_Framework_Constraint_Callback(
-                    function ($param) use ($data) {
-                        return $param['status'] === $data[2]
-                               && $param['storeReference'] === $data[3]
-                               && $param['message'] === $data[4]
-                               && !empty($param['acknowledgedAt']);
-                    }
-                )
+                Sdk\Api\Order\OrderOperation::TYPE_UNACKNOWLEDGE
             );
 
         $this->assertInstanceOf(


### PR DESCRIPTION
### Reason for this PR
When using the SDK the format for `acknowledgeAt` is not in ISO format

### What does the PR do
Send the proper format.

### How to test
With this script you should see messages in the `sf.api.order:update` queue with the field `acknowledgeAt` properly formated in ISO8601 format

```php
namespace ShoppingFeed\Sdk;

require_once 'vendor/autoload.php';

$credential    = new Credential\Token([TOKEN]);
$clientOptions = new \ShoppingFeed\Sdk\Client\ClientOptions();
$clientOptions->setBaseUri('http://api.shopping-feed.lan');

$client  = new \ShoppingFeed\Sdk\Client\Client($clientOptions);
$session = $client->authenticate($credential);

$orderApi  = $session->getMainStore()->getOrderApi();
$operation = new Api\Order\OrderOperation();
$criteria = [
    'filters' => [
        'acknowledgment' => 'unacknowledged' // we only want order with shipped or cancelled status
    ]
];
foreach($orderApi->getAll($criteria['filters']) as $order) {
    // acknowledge all order unacknowledge
    $operation->acknowledge($order->getReference(), $order->getChannel()->getName(), 'success', 'sfeed-ack-' . $order->getId());
}
if ($operation->count()) {
    $response = $orderApi->execute($operation);
    print_r($response->toArray());
}
```


