### PR TITLE
Add store channel API resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+v0.2.3
+======
+
+- Add store channel resource token getter [#59](https://github.com/shoppingflux/php-sdk/pull/59)
+
+v0.2.2-beta.1
+=============
+
+- Remove Guzzle library dependency [#50](https://github.com/shoppingflux/php-sdk/issues/50)
+- Add order collection filter documentation [#55](https://github.com/shoppingflux/php-sdk/issues/55)
+- Fix behaviour when no inventory is updated when doing an inventory update [#52](https://github.com/shoppingflux/php-sdk/issues/52)
+- Fix order acknowledge date handling [#57](https://github.com/shoppingflux/php-sdk/issues/57)
+
 v0.2.1-beta.1
 =============
 

--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
   },
   "require-dev": {
     "monolog/monolog": "^1.23",
+    "guzzlehttp/guzzle": "^6.0",
     "phpunit/phpunit": "^5.0",
     "squizlabs/php_codesniffer": "^2.8"
   },

--- a/src/Api/Store/StoreChannelDomain.php
+++ b/src/Api/Store/StoreChannelDomain.php
@@ -1,0 +1,15 @@
+<?php
+namespace ShoppingFeed\Sdk\Api\Store;
+
+use ShoppingFeed\Sdk\Resource;
+
+/**
+ * @method StoreChannelResource[] getIterator()
+ * @method StoreChannelResource[] getAll($criteria = [])
+ * @method StoreChannelResource[] getPage(array $criteria = [])
+ * @method StoreChannelResource[] getPages(array $criteria = [])
+ */
+class StoreChannelDomain extends Resource\AbstractDomainResource
+{
+    protected $resourceClass = StoreChannelResource::class;
+}

--- a/src/Api/Store/StoreChannelResource.php
+++ b/src/Api/Store/StoreChannelResource.php
@@ -1,0 +1,74 @@
+<?php
+namespace ShoppingFeed\Sdk\Api\Store;
+
+use ShoppingFeed\Sdk\Api\Channel;
+use ShoppingFeed\Sdk\Resource;
+
+class StoreChannelResource extends Resource\AbstractResource
+{
+    private $channel;
+
+    /**
+     * The channel's id
+     *
+     * @return int
+     */
+    public function getId()
+    {
+        return $this->resource->getProperty('id');
+    }
+
+    /**
+     * The channel's name
+     *
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->getChannel()->getName();
+    }
+
+    /**
+     * The channel's type
+     *
+     * @return string
+     */
+    public function getType()
+    {
+        return $this->getChannel()->getType();
+    }
+
+    /**
+     * The channel's segment
+     *
+     * @return string
+     */
+    public function getSegment()
+    {
+        return $this->getChannel()->getSegment();
+    }
+
+    /**
+     * Determine if the store is connected to the channel
+     *
+     * @return bool
+     */
+    public function isInstalled()
+    {
+        return $this->resource->getProperty('installed');
+    }
+
+    /**
+     * Fetch the inner channel as resource
+     *
+     * @return Channel\ChannelResource
+     */
+    public function getChannel()
+    {
+        if (null === $this->channel) {
+            $this->channel = new Channel\ChannelResource($this->resource->getFirstResource('channel'));
+        }
+
+        return $this->channel;
+    }
+}

--- a/src/Api/Store/StoreResource.php
+++ b/src/Api/Store/StoreResource.php
@@ -40,6 +40,16 @@ class StoreResource extends AbstractResource
     }
 
     /**
+     * @return StoreChannelDomain
+     */
+    public function getChannelApi()
+    {
+        return new StoreChannelDomain(
+            $this->resource->getLink('channel')
+        );
+    }
+
+    /**
      * @return InventoryDomain
      */
     public function getInventoryApi()

--- a/tests/unit/Api/AbstractResourceTest.php
+++ b/tests/unit/Api/AbstractResourceTest.php
@@ -11,16 +11,37 @@ abstract class AbstractResourceTest extends TestCase
      */
     protected $halResource;
 
+    /**
+     * @var array
+     */
     protected $props = [];
 
+    /**
+     * @return \PHPUnit_Framework_MockObject_MockObject|HalResource
+     */
+    protected function initHalResource()
+    {
+        $this->halResource = $this->createMock(HalResource::class);
+
+        // supports initialization by default
+        $this->halResource->method('get')->willReturnSelf();
+
+        return $this->halResource;
+    }
+
+    /**
+     * @param array $props
+     *
+     * @return \PHPUnit_Framework_MockObject_MockObject|HalResource
+     */
     protected function initHalResourceProperties(array $props = [])
     {
         if (! $props) {
             $props = $this->props;
         }
 
-        $this->halResource = $this->createMock(HalResource::class);
-        $this->halResource
+        $resource = $this->initHalResource();
+        $resource
             ->expects($this->exactly(count($props)))
             ->method('getProperty')
             ->with($this->logicalOr(...array_keys($props)))
@@ -28,9 +49,6 @@ abstract class AbstractResourceTest extends TestCase
                 return $props[$prop];
             }));
 
-        // supports initialization by default
-        $this->halResource
-            ->method('get')
-            ->willReturnSelf();
+        return $resource;
     }
 }

--- a/tests/unit/Api/Store/StoreChannelResourceTest.php
+++ b/tests/unit/Api/Store/StoreChannelResourceTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace ShoppingFeed\Sdk\Api\Store;
+
+use ShoppingFeed\Sdk;
+
+class StoreChannelResourceTest extends Sdk\Test\Api\AbstractResourceTest
+{
+    public function testPropertiesGetters()
+    {
+        $hal = $this->initHalResourceProperties([
+            'id'        => 10,
+            'installed' => true,
+        ]);
+
+        $instance = new Sdk\Api\Store\StoreChannelResource($hal);
+
+        $this->assertEquals(10, $instance->getId());
+        $this->assertEquals(true, $instance->isInstalled());
+    }
+
+    public function testChannelPropertiesGetters()
+    {
+        $hal = $this->initHalResource();
+        $hal
+            ->expects($this->once())
+            ->method('getFirstResource')
+            ->with('channel')
+            ->willReturnSelf();
+
+        $hal
+            ->expects($this->any())
+            ->method('getProperty')
+            ->withConsecutive(['name'], ['segment'], ['type'])
+            ->willReturnOnConsecutiveCalls('amazon', 'all', 'marketplace');
+
+
+        $instance = new Sdk\Api\Store\StoreChannelResource($hal);
+        $this->assertSame(
+            'amazon',
+            $instance->getName(),
+            'name is grabbed from embedded resource'
+        );
+        $this->assertSame(
+            'all',
+            $instance->getSegment(),
+            'name is grabbed from embedded resource'
+        );
+        $this->assertSame(
+            'marketplace',
+            $instance->getType(),
+            'name is grabbed from embedded resource'
+        );
+
+        $this->assertInstanceOf(
+            Sdk\Api\Channel\ChannelResource::class,
+            $instance->getChannel(),
+            'Channel instance is associated to the resource'
+        );
+    }
+}
+

--- a/tests/unit/Api/Store/StoreResourceTest.php
+++ b/tests/unit/Api/Store/StoreResourceTest.php
@@ -44,6 +44,26 @@ class StoreResourceTest extends Sdk\Test\Api\AbstractResourceTest
         $this->assertInstanceOf(Sdk\Api\Catalog\InventoryDomain::class, $instance->getInventoryApi());
     }
 
+    public function testGetChannelApi()
+    {
+        /** @var Sdk\Hal\HalResource|\PHPUnit_Framework_MockObject_MockObject $halResource */
+        $halResource = $this->createMock(Sdk\Hal\HalResource::class);
+        $halResource
+            ->expects($this->once())
+            ->method('getLink')
+            ->with('channel')
+            ->willReturn(
+                $this->createMock(Sdk\Hal\HalLink::class)
+            );
+
+        $instance = new Sdk\Api\Store\StoreResource($halResource);
+
+        $this->assertInstanceOf(
+            Sdk\Api\Store\StoreChannelDomain::class,
+            $instance->getChannelApi()
+        );
+    }
+
     public function testGetOrderApi()
     {
         /** @var Sdk\Hal\HalResource|\PHPUnit_Framework_MockObject_MockObject $halResource */


### PR DESCRIPTION
### What does the PR do

We must be able to get channel's associated to a particular store, so a new Api has been introduced.

Usage example:

```php
<?php

$channels = $store->getChannelApi();
$installed = $channels->getAll([’status' => 'installed']);
```

### How to test
Give a quick explanation on how to test the modification
