### PR TITLE
Fix client version and add user agent platform info

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,8 +5,7 @@
   "description": "Shopping Feed SDK to ease integration of our API",
   "require": {
     "php": ">= 5.6",
-    "ext-json": "*",
-    "shoppingfeed/php-feed-generator": "1.0.0"
+    "ext-json": "*"
   },
   "autoload": {
     "psr-4": {
@@ -16,7 +15,8 @@
   },
   "suggest": {
     "psr/log": "trace HTTP requests performed by the SDK",
-    "guzzlehttp/guzzle": "Guzzle Http 6 is the default http adapter integrated in the SDK"
+    "guzzlehttp/guzzle": "Guzzle Http 6 is the default http adapter integrated in the SDK",
+    "shoppingfeed/php-feed-generator": "Generates compliant Shopping-Feed XML feed with ease"
   },
   "require-dev": {
     "monolog/monolog": "^1.23",

--- a/docs/manual/authenticate.md
+++ b/docs/manual/authenticate.md
@@ -34,7 +34,7 @@ $session    = Client\Client::createSession($credential);
 ```
 
 
-### Passing client options
+### Client options
 
 Optionally, you can pass options when creating a new session with the static method.
 
@@ -44,7 +44,20 @@ namespace ShoppingFeed\Sdk;
 
 $options = new Client\ClientOptions();
 $options->setHandleRateLimit(false);
+$options->setUserAgentDetails('Magento', '2.2.0');
 
 $credential = new Credential\Token('api_token');
 $session    = Client\Client::createSession($credential, $options);
 ```
+
+Available options are:
+
+| Name               | Description                                                                                                   |
+|--------------------|---------------------------------------------------------------------------------------------------------------|
+| userAgentDetails   | Allow to add information regarding the platform and its version to user agent HTTP header sent by the sdk     |
+| headers            | Allow to add headers to all HTTP calls made by the SDK                                                        |
+| httpAdapter        | Allow to set your own HTTP adapter used by the SDK (cf. [http adapter doc](./../development/http-adapter.md)) |
+| retryOnServerError | Allow to set the number of time the SDK should retry when a server error is happening                         |
+| handleRateLimit    | Allow to enable/disable the retry of a call when server is overloaded                                         |
+| logger             | Allow to pass your own logger, logger should be a Psr\LoggerInterface to be compatible with the client        |
+| baseUri            | Allow to set the ShoppingFeed API baseUri to be used by the SDK                                               |

--- a/docs/manual/authenticate.md
+++ b/docs/manual/authenticate.md
@@ -44,7 +44,7 @@ namespace ShoppingFeed\Sdk;
 
 $options = new Client\ClientOptions();
 $options->setHandleRateLimit(false);
-$options->setUserAgentDetails('Magento', '2.2.0');
+$options->setPlatform('Magento', '2.2.0');
 
 $credential = new Credential\Token('api_token');
 $session    = Client\Client::createSession($credential, $options);
@@ -54,7 +54,7 @@ Available options are:
 
 | Name               | Description                                                                                                   |
 |--------------------|---------------------------------------------------------------------------------------------------------------|
-| userAgentDetails   | Allow to add information regarding the platform and its version to user agent HTTP header sent by the sdk     |
+| platform   | Allow to add information regarding the platform and its version to user agent HTTP header sent by the sdk     |
 | headers            | Allow to add headers to all HTTP calls made by the SDK                                                        |
 | httpAdapter        | Allow to set your own HTTP adapter used by the SDK (cf. [http adapter doc](./../development/http-adapter.md)) |
 | retryOnServerError | Allow to set the number of time the SDK should retry when a server error is happening                         |

--- a/docs/manual/resources/inventory.md
+++ b/docs/manual/resources/inventory.md
@@ -1,4 +1,4 @@
-# inventories operations
+# Inventory operations
 
 ### Read inventories
 

--- a/src/Client/Client.php
+++ b/src/Client/Client.php
@@ -25,6 +25,9 @@ class Client
         return (new self($options))->authenticate($credential);
     }
 
+    /**
+     * @param ClientOptions|null $options
+     */
     public function __construct(ClientOptions $options = null)
     {
         if (null === $options) {

--- a/src/Client/Client.php
+++ b/src/Client/Client.php
@@ -7,7 +7,7 @@ use ShoppingFeed\Sdk\Http;
 
 class Client
 {
-    const VERSION = '1.0.0';
+    const VERSION = '0.2.3';
 
     /**
      * @var Hal\HalClient

--- a/src/Client/Client.php
+++ b/src/Client/Client.php
@@ -7,7 +7,7 @@ use ShoppingFeed\Sdk\Http;
 
 class Client
 {
-    const VERSION = '0.2.3';
+    const VERSION = '0.2.4';
 
     /**
      * @var Hal\HalClient

--- a/src/Client/ClientOptions.php
+++ b/src/Client/ClientOptions.php
@@ -159,4 +159,19 @@ class ClientOptions
 
         return $this;
     }
+
+    /**
+     * Add platform information to sdk user agent
+     *
+     * @param string $plateform
+     * @param string $version
+     *
+     * @return ClientOptions
+     */
+    public function setUserAgentDetails($plateform, $version)
+    {
+        $this->headers['User-Agent'] .= " ($plateform;$version)";
+
+        return $this;
+    }
 }

--- a/src/Client/ClientOptions.php
+++ b/src/Client/ClientOptions.php
@@ -32,11 +32,6 @@ class ClientOptions
     private $httpAdapter;
 
     /**
-     * @var string
-     */
-    private $userAgent = 'SF-SDK-PHP/' . Client::VERSION;
-
-    /**
      * Name of the platform using the SDK
      *
      * @var string
@@ -163,9 +158,15 @@ class ClientOptions
      */
     public function getHeaders()
     {
-        $this->buildUserAgentHeader();
+        $headers               = $this->headers;
+        $headers['User-Agent'] = sprintf(
+            'SF-SDK-PHP/%s (%s; %s)',
+            Client::VERSION,
+            $this->platform ?: gethostname(),
+            $this->platformVersion ?: 'Unknown'
+        );
 
-        return $this->headers;
+        return $headers;
     }
 
     /**
@@ -181,29 +182,19 @@ class ClientOptions
     }
 
     /**
-     * Add platform information for SDK user agent
+     * Add platform information for SDK user agent, useful
+     * for getting more accurate help from SF support team
      *
-     * @param string $platform
-     * @param string $version
+     * @param string $platform  The platform name (ex: Magento, Prestashop...etc)
+     * @param string $version   The platform version (ex: "1.2", "1.4.2")
      *
      * @return ClientOptions
      */
-    public function setUserAgentDetails($platform, $version)
+    public function setPlatform($platform, $version)
     {
         $this->platform        = $platform;
         $this->platformVersion = $version;
 
         return $this;
-    }
-
-    /**
-     * Build user agent http header based on available information
-     */
-    private function buildUserAgentHeader()
-    {
-        $this->headers['User-Agent'] = $this->userAgent;
-        if (! empty($this->platform)) {
-            $this->headers['User-Agent'] .= " ($this->platform;$this->platformVersion)";
-        }
     }
 }

--- a/src/Client/ClientOptions.php
+++ b/src/Client/ClientOptions.php
@@ -32,11 +32,29 @@ class ClientOptions
     private $httpAdapter;
 
     /**
+     * @var string
+     */
+    private $userAgent = 'SF-SDK-PHP/' . Client::VERSION;
+
+    /**
+     * Name of the platform using the SDK
+     *
+     * @var string
+     */
+    private $platform;
+
+    /**
+     * Version of the platform using the SDK
+     *
+     * @var string
+     */
+    private $platformVersion;
+
+    /**
      * @var array
      */
     private $headers = [
         'Accept'          => 'application/json',
-        'User-Agent'      => 'SF-SDK-PHP/' . Client::VERSION,
         'Accept-Encoding' => 'gzip',
     ];
 
@@ -145,6 +163,8 @@ class ClientOptions
      */
     public function getHeaders()
     {
+        $this->buildUserAgentHeader();
+
         return $this->headers;
     }
 
@@ -161,17 +181,29 @@ class ClientOptions
     }
 
     /**
-     * Add platform information to sdk user agent
+     * Add platform information for SDK user agent
      *
-     * @param string $plateform
+     * @param string $platform
      * @param string $version
      *
      * @return ClientOptions
      */
-    public function setUserAgentDetails($plateform, $version)
+    public function setUserAgentDetails($platform, $version)
     {
-        $this->headers['User-Agent'] .= " ($plateform;$version)";
+        $this->platform        = $platform;
+        $this->platformVersion = $version;
 
         return $this;
+    }
+
+    /**
+     * Build user agent http header based on available information
+     */
+    private function buildUserAgentHeader()
+    {
+        $this->headers['User-Agent'] = $this->userAgent;
+        if (! empty($this->platform)) {
+            $this->headers['User-Agent'] .= " ($this->platform;$this->platformVersion)";
+        }
     }
 }

--- a/tests/unit/Client/ClientOptionsTest.php
+++ b/tests/unit/Client/ClientOptionsTest.php
@@ -3,6 +3,7 @@ namespace ShoppingFeed\Sdk\Test\Client;
 
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
+use ShoppingFeed\Sdk\Client\Client;
 use ShoppingFeed\Sdk\Client\ClientOptions;
 
 class ClientOptionsTest extends TestCase
@@ -18,12 +19,13 @@ class ClientOptionsTest extends TestCase
             ->setLogger($logger)
             ->setRetryOnServerError(5)
             ->setHandleRateLimit(true)
+            ->setUserAgentDetails('MyPlatform', '1.1.4')
             ->setBaseUri($uri);
 
         $headers = [
             'HeaderName'      => 'HeaderValue',
             'Accept'          => 'application/json',
-            'User-Agent'      => 'SF-SDK-PHP/1.0.0',
+            'User-Agent'      => 'SF-SDK-PHP/' . Client::VERSION . ' (MyPlatform;1.1.4)',
             'Accept-Encoding' => 'gzip',
         ];
 

--- a/tests/unit/Client/ClientOptionsTest.php
+++ b/tests/unit/Client/ClientOptionsTest.php
@@ -19,13 +19,13 @@ class ClientOptionsTest extends TestCase
             ->setLogger($logger)
             ->setRetryOnServerError(5)
             ->setHandleRateLimit(true)
-            ->setUserAgentDetails('MyPlatform', '1.1.4')
+            ->setPlatform('MyPlatform', '1.1.4')
             ->setBaseUri($uri);
 
         $headers = [
             'HeaderName'      => 'HeaderValue',
             'Accept'          => 'application/json',
-            'User-Agent'      => 'SF-SDK-PHP/' . Client::VERSION . ' (MyPlatform;1.1.4)',
+            'User-Agent'      => 'SF-SDK-PHP/' . Client::VERSION . ' (MyPlatform; 1.1.4)',
             'Accept-Encoding' => 'gzip',
         ];
 


### PR DESCRIPTION
### Link to the issue
This resolves #60 #61 

### Reason for this PR
The version returned by the client is not the one tagged in the repository. 
We needed to add some informations on the platform using the SDK to help integration and debug.

### What does the PR do
Sync the version with the repo.
Allow to add platform information to SDK user agent.

### How to test
On the client when calling `Client::VERSION` the version returned should be 0.2.4.
When setting `userAgentDetails` informations on `ClientOptions` all call made by the SDK should contain the platform used and its version

