### PR TITLE
Add more info on session resource & getOne domain method

### DIFF
--- a/src/Api/Catalog/InventoryDomain.php
+++ b/src/Api/Catalog/InventoryDomain.php
@@ -1,20 +1,19 @@
 <?php
 namespace ShoppingFeed\Sdk\Api\Catalog;
 
-use ShoppingFeed\Sdk\Api\Catalog as ApiCatalog;
-use ShoppingFeed\Sdk\Catalog;
 use ShoppingFeed\Sdk\Resource\AbstractDomainResource;
 
 /**
- * @method ApiCatalog\InventoryResource[] getIterator()
- * @method ApiCatalog\InventoryResource[] getAll($page = 1, $limit = 100)
+ * @method InventoryResource[] getIterator()
+ * @method InventoryResource[] getAll($page = 1, $limit = 100)
+ * @method InventoryResource getOne($identity)
  */
 class InventoryDomain extends AbstractDomainResource
 {
     /**
      * @var string
      */
-    protected $resourceClass = ApiCatalog\InventoryResource::class;
+    protected $resourceClass = InventoryResource::class;
 
     /**
      * @param string $reference the resource reference
@@ -24,8 +23,8 @@ class InventoryDomain extends AbstractDomainResource
     public function getByReference($reference)
     {
         $resource = $this->link->get([], ['query' => ['reference' => $reference]]);
-        if ($resource->getProperty('count') > 0) {
-            return new ApiCatalog\InventoryResource(
+        if ($resource && $resource->getProperty('count') > 0) {
+            return new InventoryResource(
                 $resource->getFirstResource('inventory'),
                 false
             );

--- a/src/Api/Order/OrderDomain.php
+++ b/src/Api/Order/OrderDomain.php
@@ -1,21 +1,21 @@
 <?php
 namespace ShoppingFeed\Sdk\Api\Order;
 
-use ShoppingFeed\Sdk\Api\Order as ApiOrder;
 use ShoppingFeed\Sdk\Resource\AbstractDomainResource;
 
 /**
- * @method ApiOrder\OrderResource[] getIterator()
- * @method ApiOrder\OrderResource[] getAll($criteria = [])
- * @method ApiOrder\OrderResource[] getPage(array $criteria = [])
- * @method ApiOrder\OrderResource[] getPages(array $criteria = [])
+ * @method OrderResource[] getIterator()
+ * @method OrderResource[] getAll($criteria = [])
+ * @method OrderResource[] getPage(array $criteria = [])
+ * @method OrderResource[] getPages(array $criteria = [])
+ * @method OrderResource getOne($identity)
  */
 class OrderDomain extends AbstractDomainResource
 {
     /**
      * @var string
      */
-    protected $resourceClass = ApiOrder\OrderResource::class;
+    protected $resourceClass = OrderResource::class;
 
     /**
      * @param OrderOperation $operation

--- a/src/Api/Session/SessionResource.php
+++ b/src/Api/Session/SessionResource.php
@@ -31,7 +31,7 @@ class SessionResource extends AbstractResource
      */
     public function getLogin()
     {
-        return $this->resource->getProperty('login');
+        return (string) $this->resource->getProperty('login');
     }
 
     /**
@@ -39,7 +39,7 @@ class SessionResource extends AbstractResource
      */
     public function getEmail()
     {
-        return $this->resource->getProperty('email');
+        return (string) $this->resource->getProperty('email');
     }
 
     /**
@@ -47,7 +47,7 @@ class SessionResource extends AbstractResource
      */
     public function getToken()
     {
-        return $this->resource->getProperty('token');
+        return (string) $this->resource->getProperty('token');
     }
 
     /**
@@ -58,6 +58,21 @@ class SessionResource extends AbstractResource
         return new Store\StoreCollection(
             $this->resource->getResources('store')
         );
+    }
+
+    /**
+     * Return the language tag, as following:
+     *
+     * - en_US
+     * - fr_FR
+     *
+     * ...etc
+     *
+     * @return string
+     */
+    public function getLanguageTag()
+    {
+        return (string) $this->resource->getProperty('language');
     }
 
     /**

--- a/src/Api/Session/SessionResource.php
+++ b/src/Api/Session/SessionResource.php
@@ -51,7 +51,7 @@ class SessionResource extends AbstractResource
     }
 
     /**
-     * @return Store\StoreCollection
+     * @return Store\StoreCollection|Store\StoreResource[]
      */
     public function getStores()
     {

--- a/src/Api/Session/SessionResource.php
+++ b/src/Api/Session/SessionResource.php
@@ -7,6 +7,26 @@ use ShoppingFeed\Sdk\Api\Store;
 class SessionResource extends AbstractResource
 {
     /**
+     * @return int|null NULL when account id is not found, id integer otherwise
+     */
+    public function getId()
+    {
+        if ($account = $this->resource->getFirstResource('account')) {
+            return $account->getProperty('id');
+        }
+
+        return null;
+    }
+
+    /**
+     * @return array A list of named roles
+     */
+    public function getRoles()
+    {
+        return $this->getProperty('roles') ?: [];
+    }
+
+    /**
      * @return string
      */
     public function getLogin()

--- a/src/Api/Store/StoreChannelDomain.php
+++ b/src/Api/Store/StoreChannelDomain.php
@@ -8,6 +8,7 @@ use ShoppingFeed\Sdk\Resource;
  * @method StoreChannelResource[] getAll($criteria = [])
  * @method StoreChannelResource[] getPage(array $criteria = [])
  * @method StoreChannelResource[] getPages(array $criteria = [])
+ * @method StoreChannelResource getOne($identity)
  */
 class StoreChannelDomain extends Resource\AbstractDomainResource
 {

--- a/src/Api/Store/StoreChannelResource.php
+++ b/src/Api/Store/StoreChannelResource.php
@@ -66,7 +66,9 @@ class StoreChannelResource extends Resource\AbstractResource
     public function getChannel()
     {
         if (null === $this->channel) {
-            $this->channel = new Channel\ChannelResource($this->resource->getFirstResource('channel'));
+            $this->channel = new Channel\ChannelResource(
+                $this->resource->getFirstResource('channel')
+            );
         }
 
         return $this->channel;

--- a/src/Api/Store/StoreResource.php
+++ b/src/Api/Store/StoreResource.php
@@ -32,6 +32,18 @@ class StoreResource extends AbstractResource
     }
 
     /**
+     * @return string One of the following status:
+     *  - active
+     *  - demo
+     *  - deleted
+     *  - suspended
+     */
+    public function getStatus()
+    {
+        return $this->getProperty('status');
+    }
+
+    /**
      * @return string
      */
     public function getCountryCode()

--- a/src/Hal/HalLink.php
+++ b/src/Hal/HalLink.php
@@ -124,8 +124,6 @@ class HalLink
      * @param array $variables
      *
      * @return null|string|string[]
-     *
-     * @throws \QL\UriTemplate\Exception
      */
     public function getUri(array $variables)
     {

--- a/src/Hal/HalLink.php
+++ b/src/Hal/HalLink.php
@@ -108,6 +108,19 @@ class HalLink
     }
 
     /**
+     * @param $path
+     *
+     * @return HalLink
+     */
+    public function withAddedHref($path)
+    {
+        $instance       = clone $this;
+        $instance->href = rtrim($instance->href, '/') . '/' . ltrim($path, '/');
+
+        return $instance;
+    }
+
+    /**
      * @param array $variables
      *
      * @return null|string|string[]

--- a/src/Resource/AbstractDomainResource.php
+++ b/src/Resource/AbstractDomainResource.php
@@ -26,6 +26,21 @@ abstract class AbstractDomainResource
     }
 
     /**
+     * Get the resource by it's identity
+     *
+     * @param mixed $identity a scalar value that identity the resource
+     *
+     * @return AbstractResource
+     */
+    public function getOne($identity)
+    {
+        $link  = $this->link->withAddedHref($identity);
+        $class = $this->resourceClass;
+
+        return new $class($link->get());
+    }
+
+    /**
      * @param array $criteria
      *
      * @return null|PaginatedResourceCollection

--- a/tests/unit/Api/AbstractResourceTest.php
+++ b/tests/unit/Api/AbstractResourceTest.php
@@ -42,7 +42,7 @@ abstract class AbstractResourceTest extends TestCase
 
         $resource = $this->initHalResource();
         $resource
-            ->expects($this->exactly(count($props)))
+            ->expects($this->any())
             ->method('getProperty')
             ->with($this->logicalOr(...array_keys($props)))
             ->will($this->returnCallback(function($prop) use($props) {

--- a/tests/unit/Api/Session/SessionResourceTest.php
+++ b/tests/unit/Api/Session/SessionResourceTest.php
@@ -12,12 +12,14 @@ class SessionResourceTest extends Sdk\Test\Api\AbstractResourceTest
 
     public function setUp()
     {
-        $this->props     = [
-            'login' => 'username',
-            'email' => 'user@mail.com',
-            'token' => 'fd9cf7c178a1efd30bb1aad0e302abde',
-            'roles' => ['user']
+        $this->props = [
+            'login'    => 'username',
+            'email'    => 'user@mail.com',
+            'token'    => 'fd9cf7c178a1efd30bb1aad0e302abde',
+            'language' => 'en_US',
+            'roles'    => ['user'],
         ];
+
         $this->resources = [
             $this->createMock(Sdk\Hal\HalResource::class),
             $this->createMock(Sdk\Hal\HalResource::class),
@@ -35,6 +37,7 @@ class SessionResourceTest extends Sdk\Test\Api\AbstractResourceTest
         $this->assertEquals($this->props['login'], $instance->getLogin());
         $this->assertEquals($this->props['token'], $instance->getToken());
         $this->assertEquals($this->props['roles'], $instance->getRoles());
+        $this->assertEquals($this->props['language'], $instance->getLanguageTag());
     }
 
     public function testGetAccountIdWithMatchedOrNullAccount()

--- a/tests/unit/Api/Session/SessionResourceTest.php
+++ b/tests/unit/Api/Session/SessionResourceTest.php
@@ -16,6 +16,7 @@ class SessionResourceTest extends Sdk\Test\Api\AbstractResourceTest
             'login' => 'username',
             'email' => 'user@mail.com',
             'token' => 'fd9cf7c178a1efd30bb1aad0e302abde',
+            'roles' => ['user']
         ];
         $this->resources = [
             $this->createMock(Sdk\Hal\HalResource::class),
@@ -33,6 +34,30 @@ class SessionResourceTest extends Sdk\Test\Api\AbstractResourceTest
         $this->assertEquals($this->props['email'], $instance->getEmail());
         $this->assertEquals($this->props['login'], $instance->getLogin());
         $this->assertEquals($this->props['token'], $instance->getToken());
+        $this->assertEquals($this->props['roles'], $instance->getRoles());
+    }
+
+    public function testGetAccountIdWithMatchedOrNullAccount()
+    {
+        $halResource = $this->createMock(Sdk\Hal\HalResource::class);
+        $halResource
+            ->expects($this->exactly(2))
+            ->method('getFirstResource')
+            ->with('account')
+            ->willReturnOnConsecutiveCalls(
+                $halResource,
+                null
+            );
+
+        $halResource
+            ->expects($this->once())
+            ->method('getProperty')
+            ->with('id')
+            ->willReturn(12);
+
+        $instance = new Sdk\Api\Session\SessionResource($halResource);
+        $this->assertSame(12, $instance->getId(), 'First call resource will return mock');
+        $this->assertNull($instance->getId(), 'Second resource call return NULL');
     }
 
     public function testGetStores()

--- a/tests/unit/Api/Store/StoreResourceTest.php
+++ b/tests/unit/Api/Store/StoreResourceTest.php
@@ -21,9 +21,10 @@ class StoreResourceTest extends Sdk\Test\Api\AbstractResourceTest
 
         $instance = new Sdk\Api\Store\StoreResource($this->halResource);
 
-        $this->assertEquals($this->props['id'], $instance->getId());
-        $this->assertEquals($this->props['name'], $instance->getName());
-        $this->assertEquals($this->props['country'], $instance->getCountryCode());
+        $this->assertSame($this->props['id'], $instance->getId());
+        $this->assertSame($this->props['name'], $instance->getName());
+        $this->assertSame($this->props['country'], $instance->getCountryCode());
+        $this->assertSame('active', $instance->getStatus());
         $this->assertTrue($instance->isActive());
     }
 

--- a/tests/unit/Hal/HalLinkTest.php
+++ b/tests/unit/Hal/HalLinkTest.php
@@ -11,11 +11,20 @@ use ShoppingFeed\Sdk\Hal\HalResource;
 
 class HalLinkTest extends TestCase
 {
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject|HalClient
+     */
+    private $client;
+
+    public function setUp()
+    {
+        $this->client = $this->createMock(HalClient::class);
+    }
+
     public function testSetters()
     {
-        $client   = $this->createMock(HalClient::class);
         $instance = new HalLink(
-            $client,
+            $this->client,
             'http://base.url',
             [
                 'templated' => true,
@@ -37,8 +46,7 @@ class HalLinkTest extends TestCase
      */
     public function testHttpClientCalls()
     {
-        $client = $this->createMock(HalClient::class);
-        $client
+        $this->client
             ->expects($this->exactly(5))
             ->method('send')
             ->willReturn(
@@ -47,7 +55,7 @@ class HalLinkTest extends TestCase
 
         $instance = $this
             ->getMockBuilder(HalLink::class)
-            ->setConstructorArgs([$client, 'http://base.url'])
+            ->setConstructorArgs([$this->client, 'http://base.url'])
             ->setMethods(['createRequest'])
             ->getMock();
 
@@ -67,8 +75,7 @@ class HalLinkTest extends TestCase
 
     public function testSend()
     {
-        $client = $this->createMock(HalClient::class);
-        $client
+        $this->client
             ->expects($this->once())
             ->method('send')
             ->willReturn(
@@ -77,7 +84,7 @@ class HalLinkTest extends TestCase
 
         $instance = $this
             ->getMockBuilder(HalLink::class)
-            ->setConstructorArgs([$client, 'http://base.url'])
+            ->setConstructorArgs([$this->client, 'http://base.url'])
             ->setMethods(['createRequest'])
             ->getMock();
 
@@ -88,8 +95,7 @@ class HalLinkTest extends TestCase
 
     public function testGetCreateRequest()
     {
-        $client = $this->createMock(HalClient::class);
-        $client
+        $this->client
             ->expects($this->once())
             ->method('createRequest')
             ->willReturn(
@@ -98,7 +104,7 @@ class HalLinkTest extends TestCase
 
         $instance = $this
             ->getMockBuilder(HalLink::class)
-            ->setConstructorArgs([$client, 'http://base.url'])
+            ->setConstructorArgs([$this->client, 'http://base.url'])
             ->setMethods(['getUri'])
             ->getMock();
 
@@ -112,8 +118,7 @@ class HalLinkTest extends TestCase
 
     public function testCreateRequestWithContent()
     {
-        $client = $this->createMock(HalClient::class);
-        $client
+        $this->client
             ->expects($this->exactly(3))
             ->method('createRequest')
             ->willReturn(
@@ -122,7 +127,7 @@ class HalLinkTest extends TestCase
 
         $instance = $this
             ->getMockBuilder(HalLink::class)
-            ->setConstructorArgs([$client, 'http://base.url'])
+            ->setConstructorArgs([$this->client, 'http://base.url'])
             ->setMethods(['getUri'])
             ->getMock();
 
@@ -139,8 +144,7 @@ class HalLinkTest extends TestCase
     public function testBatchSend()
     {
         $request = ['request'];
-        $client  = $this->createMock(HalClient::class);
-        $client
+        $this->client
             ->expects($this->once())
             ->method('batchSend')
             ->with(
@@ -151,7 +155,7 @@ class HalLinkTest extends TestCase
                 )
             );
 
-        $instance = new HalLink($client, 'http://base.url');
+        $instance = new HalLink($this->client, 'http://base.url');
 
         $instance->batchSend($request);
     }
@@ -160,8 +164,7 @@ class HalLinkTest extends TestCase
     {
         $request = ['request'];
         $options = ['test' => 'option'];
-        $client  = $this->createMock(HalClient::class);
-        $client
+        $this->client
             ->expects($this->once())
             ->method('batchSend')
             ->with(
@@ -177,7 +180,7 @@ class HalLinkTest extends TestCase
                 )
             );
 
-        $instance = new HalLink($client, 'http://base.url');
+        $instance = new HalLink($this->client, 'http://base.url');
 
         $instance->batchSend($request, null, null, $options);
     }
@@ -189,8 +192,7 @@ class HalLinkTest extends TestCase
         $success = function () {
             echo 'Success';
         };
-        $client  = $this->createMock(HalClient::class);
-        $client
+        $this->client
             ->expects($this->once())
             ->method('batchSend')
             ->with(
@@ -208,7 +210,7 @@ class HalLinkTest extends TestCase
                 )
             );
 
-        $instance = new HalLink($client, 'http://base.url');
+        $instance = new HalLink($this->client, 'http://base.url');
 
         $instance->batchSend($request, $success, null);
     }
@@ -220,8 +222,7 @@ class HalLinkTest extends TestCase
         $error   = function () {
             echo 'Error';
         };
-        $client  = $this->createMock(HalClient::class);
-        $client
+        $this->client
             ->expects($this->once())
             ->method('batchSend')
             ->with(
@@ -240,17 +241,16 @@ class HalLinkTest extends TestCase
                 )
             );
 
-        $instance = new HalLink($client, 'http://base.url');
+        $instance = new HalLink($this->client, 'http://base.url');
 
         $instance->batchSend($request, null, $error);
     }
 
     public function testGetUriDefault()
     {
-        $client   = $this->createMock(HalClient::class);
         $instance = $this
             ->getMockBuilder(HalLink::class)
-            ->setConstructorArgs([$client, 'http://base.url'])
+            ->setConstructorArgs([$this->client, 'http://base.url'])
             ->setMethods(['getHref'])
             ->getMock();
 
@@ -264,9 +264,31 @@ class HalLinkTest extends TestCase
 
     public function testGetUriTemplated()
     {
-        $client   = $this->createMock(HalClient::class);
-        $instance = new HalLink($client, 'http://base.url', ['templated' => true]);
+        $instance = new HalLink($this->client, 'http://base.url', ['templated' => true]);
 
         $this->assertInternalType('string', $instance->getUri([]));
+    }
+
+    /**
+     * @dataProvider addedHrefProvider
+     */
+    public function testWithAddedHref($href, $added, $expected)
+    {
+        $instance = new HalLink($this->client, $href);
+        $this->assertSame(
+            $instance->withAddedHref($added)->getHref(),
+            $expected
+        );
+    }
+
+    public function addedHrefProvider()
+    {
+        return [
+            ['http://base.url/v1', '12', 'http://base.url/v1/12'],
+            ['http://base.url/v1/', '12', 'http://base.url/v1/12'],
+            ['http://base.url/v1/', '/12', 'http://base.url/v1/12'],
+            ['http://base.url/v1', '/12', 'http://base.url/v1/12'],
+            ['http://base.url/v1', '/12/', 'http://base.url/v1/12/'],
+        ];
     }
 }

--- a/tests/unit/Resource/AbstractDomainResourceTest.php
+++ b/tests/unit/Resource/AbstractDomainResourceTest.php
@@ -2,8 +2,11 @@
 namespace ShoppingFeed\Sdk\Test\Resource;
 
 use PHPUnit\Framework\TestCase;
+use ShoppingFeed\Sdk\Hal;
 use ShoppingFeed\Sdk\Hal\HalLink;
 use ShoppingFeed\Sdk\Hal\HalResource;
+use ShoppingFeed\Sdk\Resource\AbstractDomainResource;
+use ShoppingFeed\Sdk\Resource\AbstractResource;
 use ShoppingFeed\Sdk\Resource\PaginatedResourceCollection;
 
 class AbstractDomainResourceTest extends TestCase
@@ -154,5 +157,44 @@ class AbstractDomainResourceTest extends TestCase
             ->willReturn($link);
 
         return $resource;
+    }
+
+    public function testGetOneLinkToSingleResource()
+    {
+        $link     = $this->createMock(HalLink::class);
+        $resource = $this->createMock(HalResource::class);
+
+        $link
+            ->expects($this->once())
+            ->method('withAddedHref')
+            ->with('123')
+            ->willReturnSelf();
+
+        $link
+            ->expects($this->once())
+            ->method('get')
+            ->willReturn($resource);
+
+        $instance = new AbstractDomainResourceStub($link);
+        $instance->resourceClass = AbstractDomainResourceResourceStub::class;
+
+        $result = $instance->getOne('123');
+        $this->assertInstanceOf(AbstractDomainResourceResourceStub::class, $result);
+        $this->assertSame($resource, $result->halResource);
+    }
+}
+
+class AbstractDomainResourceStub extends AbstractDomainResource
+{
+    public $resourceClass;
+}
+
+class AbstractDomainResourceResourceStub extends AbstractResource
+{
+    public $halResource;
+
+    public function __construct(Hal\HalResource $resource)
+    {
+        $this->halResource = $resource;
     }
 }


### PR DESCRIPTION
### Reason for this PR

- We need to completely implement the /me resource in order to get info internally
- The domain resource does not provides direct acres to identified resource

### Added

- `SessionResource::getId()` : provides the account id associated to the token
- `SessionResource::getRoles()` : provides an array of named roles associated to the token
- `SessionResource::getLanguageTag()` : provides the language tag associate to the token
- `AbstractDomainResource::getOne($id)` : allow to directly get a resource for the domain
- `HalLink::withAddedHref(string $path)` : Allow to creates new instance of link with concatenated path

### Bug fixes
- `InventoryDomain::getByReference()` was not checking for NULL resource

