### PR TITLE
SFAPP-397 - add pricing APIs

### DIFF
--- a/docs/manual/resources/pricing.md
+++ b/docs/manual/resources/pricing.md
@@ -1,0 +1,72 @@
+# Pricing operations
+
+### Read pricings
+
+Accessing the pricing API can be done using the store resource
+
+```php
+<?php
+$pricingApi = $session->getMainStore()->getPricingApi();
+```
+
+Find an pricing item by a product's reference (sku):
+
+```php
+<?php
+/** @var \ShoppingFeed\Sdk\Api\Catalog\PricingDomain $pricingApi */
+$item = $pricingApi->getByReference('AZUR103-XL');
+// Access the quantity as integer
+$item->getPrice();
+// Access the reference
+$item->getReference();
+// Get last modification date time
+$item->getUpdatedAt()->format('c');
+```
+
+Get a particular page of pricing
+
+```php
+<?php
+/** @var \ShoppingFeed\Sdk\Api\Catalog\PricingDomain $pricingApi */
+$criteria = [
+  'page' => 1,  
+  'limit' => 10,  
+];
+foreach ($pricingApi->getPage($criteria) as $pricing) {
+	echo $pricing->getPrice() . PHP_EOL;
+}
+```
+
+Or iterate over all pricing of your catalog
+
+```php
+<?php
+/** @var \ShoppingFeed\Sdk\Api\Catalog\PricingDomain $pricingApi */
+foreach ($pricingApi->getAll() as $pricing) {
+	echo $pricing->getPrice() . PHP_EOL;
+}
+```
+
+### Update pricing
+
+```php
+<?php
+/** @var \ShoppingFeed\Sdk\Api\Catalog\PricingDomain $pricingApi */
+$pricingUpdate = new \ShoppingFeed\Sdk\Api\Catalog\PricingUpdate();
+$pricingUpdate
+    ->add('ref1', 1.25)
+    ->add('ref2', 2.10);
+$pricingApi->execute($pricingUpdate);
+```
+
+The collection object holds updated resources
+
+```php
+<?php
+/** @var \ShoppingFeed\Sdk\Api\Catalog\PricingResource[] $collection */
+// Retrieve the content of resources
+foreach ($collection as $pricing) {
+	echo $pricing->getId() . PHP_EOL;
+	echo $pricing->getUpdatedAt()->format('c') . PHP_EOL;
+}
+```

--- a/src/Api/Catalog/PricingCollection.php
+++ b/src/Api/Catalog/PricingCollection.php
@@ -1,0 +1,9 @@
+<?php
+namespace ShoppingFeed\Sdk\Api\Catalog;
+
+use ShoppingFeed\Sdk\Resource\AbstractCollection;
+
+class PricingCollection extends AbstractCollection
+{
+    protected $resourceClass = PricingResource::class;
+}

--- a/src/Api/Catalog/PricingDomain.php
+++ b/src/Api/Catalog/PricingDomain.php
@@ -1,0 +1,47 @@
+<?php
+namespace ShoppingFeed\Sdk\Api\Catalog;
+
+use ShoppingFeed\Sdk\Resource\AbstractDomainResource;
+
+/**
+ * @method PricingResource[] getIterator()
+ * @method PricingResource[] getAll($page = 1, $limit = 100)
+ * @method PricingResource   getOne($identity)
+ */
+class PricingDomain extends AbstractDomainResource
+{
+    /**
+     * @var string
+     */
+    protected $resourceClass = PricingResource::class;
+
+    /**
+     * @param string $reference the resource reference
+     *
+     * @return null|PricingResource
+     */
+    public function getByReference($reference)
+    {
+        $resource = $this->link->get([], ['query' => ['reference' => $reference]]);
+        if ($resource && $resource->getProperty('count') > 0) {
+            return new PricingResource(
+                $resource->getFirstResource('pricing'),
+                false
+            );
+        }
+
+        return null;
+    }
+
+    /**
+     * Execute requested update
+     *
+     * @param PricingUpdate $operation
+     *
+     * @return PricingCollection
+     */
+    public function execute(PricingUpdate $operation)
+    {
+        return $operation->execute($this->link);
+    }
+}

--- a/src/Api/Catalog/PricingResource.php
+++ b/src/Api/Catalog/PricingResource.php
@@ -1,0 +1,41 @@
+<?php
+namespace ShoppingFeed\Sdk\Api\Catalog;
+
+use ShoppingFeed\Sdk\Resource\AbstractResource;
+
+class PricingResource extends AbstractResource
+{
+    /**
+     * @return int
+     */
+    public function getId()
+    {
+        return $this->getProperty('id');
+    }
+
+    /**
+     * @return float
+     */
+    public function getPrice()
+    {
+        return $this->getProperty('price');
+    }
+
+    /**
+     * @return int
+     */
+    public function getReference()
+    {
+        return $this->getProperty('reference');
+    }
+
+    /**
+     * @return \DateTimeImmutable|null
+     *
+     * @throws \Exception
+     */
+    public function getUpdatedAt()
+    {
+        return $this->getPropertyDatetime('updatedAt');
+    }
+}

--- a/src/Api/Catalog/PricingUpdate.php
+++ b/src/Api/Catalog/PricingUpdate.php
@@ -1,0 +1,94 @@
+<?php
+namespace ShoppingFeed\Sdk\Api\Catalog;
+
+use ShoppingFeed\Sdk\Hal;
+use ShoppingFeed\Sdk\Operation\AbstractBulkOperation;
+
+class PricingUpdate extends AbstractBulkOperation
+{
+    /**
+     * @param array|\Traversable $operations Optional iterable collection composed of:
+     *                                       - key (string) : product's reference
+     *                                       - value (int)  : product's new price
+     */
+    public function __construct($operations = [])
+    {
+        foreach ($operations as $reference => $price) {
+            $this->add($reference, $price);
+        }
+    }
+
+    /**
+     * @param string $reference The product's reference
+     * @param float  $price     The new product's price
+     *
+     * @return $this
+     */
+    public function add($reference, $price)
+    {
+        $reference = trim($reference);
+        $price     = (float) $price;
+
+        $this->operations[$reference] = compact('reference', 'price');
+
+        return $this;
+    }
+
+    /**
+     * @param Hal\HalLink $link
+     *
+     * @return PricingCollection
+     */
+    public function execute(Hal\HalLink $link)
+    {
+        // Create requests per batch
+        $requests = [];
+        $this->eachBatch(
+            $this->createBatchProcessorCallback($link, $requests)
+        );
+
+        // Send requests
+        $resources = [];
+        $link->batchSend(
+            $requests,
+            $this->createSuccessCallback($resources),
+            null,
+            [],
+            $this->getPoolSize()
+        );
+
+        return new PricingCollection($resources);
+    }
+
+    /**
+     * Create batch processor
+     *
+     * @param Hal\HalLink $link
+     * @param array       $requests
+     *
+     * @return \Closure
+     */
+    private function createBatchProcessorCallback(Hal\HalLink $link, array &$requests)
+    {
+        return function (array $chunk) use ($link, &$requests) {
+            $requests[] = $link->createRequest('PUT', [], ['pricing' => $chunk]);
+        };
+    }
+
+    /**
+     * Create success callback
+     *
+     * @param array $resources
+     *
+     * @return \Closure
+     */
+    private function createSuccessCallback(array &$resources)
+    {
+        return function (Hal\HalResource $resource) use (&$resources) {
+            $pricings = $resource->getResources('pricing');
+            if (count($pricings) > 0) {
+                array_push($resources, ...$pricings);
+            }
+        };
+    }
+}

--- a/src/Api/Store/StoreResource.php
+++ b/src/Api/Store/StoreResource.php
@@ -1,7 +1,7 @@
 <?php
 namespace ShoppingFeed\Sdk\Api\Store;
 
-use ShoppingFeed\Sdk\Api\Catalog\InventoryDomain;
+use ShoppingFeed\Sdk\Api\Catalog;
 use ShoppingFeed\Sdk\Api\Order\OrderDomain;
 use ShoppingFeed\Sdk\Resource\AbstractResource;
 
@@ -62,11 +62,11 @@ class StoreResource extends AbstractResource
     }
 
     /**
-     * @return InventoryDomain
+     * @return Catalog\InventoryDomain
      */
     public function getInventoryApi()
     {
-        return new InventoryDomain(
+        return new Catalog\InventoryDomain(
             $this->resource->getLink('inventory')
         );
     }
@@ -78,6 +78,16 @@ class StoreResource extends AbstractResource
     {
         return new OrderDomain(
             $this->resource->getLink('order')
+        );
+    }
+
+    /**
+     * @return Catalog\PricingDomain
+     */
+    public function getPricingApi()
+    {
+        return new Catalog\PricingDomain(
+            $this->resource->getLink('pricing')
         );
     }
 }

--- a/tests/unit/Api/Catalog/PricingDomainTest.php
+++ b/tests/unit/Api/Catalog/PricingDomainTest.php
@@ -4,7 +4,7 @@ namespace ShoppingFeed\Sdk\Test\Api\Catalog;
 use PHPUnit\Framework\TestCase;
 use ShoppingFeed\Sdk;
 
-class InventoryDomainTest extends TestCase
+class PricingDomainTest extends TestCase
 {
     public function testGetByReference()
     {
@@ -19,7 +19,7 @@ class InventoryDomainTest extends TestCase
         $resource
             ->expects($this->once())
             ->method('getFirstResource')
-            ->with('inventory')
+            ->with('pricing')
             ->willReturn(
                 $this->createMock(Sdk\Hal\HalResource::class)
             );
@@ -32,12 +32,12 @@ class InventoryDomainTest extends TestCase
             )
             ->willReturn($resource);
 
-        $instance = new Sdk\Api\Catalog\InventoryDomain($link);
+        $instance = new Sdk\Api\Catalog\PricingDomain($link);
 
-        $this->assertInstanceOf(Sdk\Api\Catalog\InventoryResource::class, $instance->getByReference($reference));
+        $this->assertInstanceOf(Sdk\Api\Catalog\PricingResource::class, $instance->getByReference($reference));
     }
 
-    public function testGetByReferenceNoInventory()
+    public function testGetByReferenceNoPricing()
     {
         $reference = 'abc213';
         $link      = $this->createMock(Sdk\Hal\HalLink::class);
@@ -56,7 +56,7 @@ class InventoryDomainTest extends TestCase
             )
             ->willReturn($resource);
 
-        $instance = new Sdk\Api\Catalog\InventoryDomain($link);
+        $instance = new Sdk\Api\Catalog\PricingDomain($link);
 
         $this->assertNull($instance->getByReference($reference));
     }
@@ -64,14 +64,14 @@ class InventoryDomainTest extends TestCase
     public function testExecute()
     {
         $link       = $this->createMock(Sdk\Hal\HalLink::class);
-        $operations = $this->createMock(Sdk\Api\Catalog\InventoryUpdate::class);
+        $operations = $this->createMock(Sdk\Api\Catalog\PricingUpdate::class);
         $operations
             ->expects($this->once())
             ->method('execute')
             ->with($link)
-            ->willReturn($this->createMock(Sdk\Api\Catalog\InventoryCollection::class));
+            ->willReturn($this->createMock(Sdk\Api\Catalog\PricingCollection::class));
 
-        $instance = new Sdk\Api\Catalog\InventoryDomain($link);
+        $instance = new Sdk\Api\Catalog\PricingDomain($link);
         $instance->execute($operations);
     }
 }

--- a/tests/unit/Api/Catalog/PricingResourceTest.php
+++ b/tests/unit/Api/Catalog/PricingResourceTest.php
@@ -1,0 +1,29 @@
+<?php
+namespace ShoppingFeed\Sdk\Test\Api\Catalog;
+
+use ShoppingFeed\Sdk;
+
+class PricingResourceTest extends Sdk\Test\Api\AbstractResourceTest
+{
+    public function setUp()
+    {
+        $this->props = [
+            'id'        => 10,
+            'reference' => 'abc123',
+            'price'     => 2.10,
+            'updatedAt' => '2018-05-04T12:04:57.451471+0200',
+        ];
+    }
+
+    public function testPropertiesGetters()
+    {
+        $this->initHalResourceProperties();
+
+        $instance = new Sdk\Api\Catalog\PricingResource($this->halResource);
+
+        $this->assertEquals($this->props['id'], $instance->getId());
+        $this->assertEquals($this->props['reference'], $instance->getReference());
+        $this->assertEquals($this->props['price'], $instance->getPrice());
+        $this->assertEquals(new \DateTimeImmutable($this->props['updatedAt']), $instance->getUpdatedAt());
+    }
+}

--- a/tests/unit/Api/Catalog/PricingUpdateTest.php
+++ b/tests/unit/Api/Catalog/PricingUpdateTest.php
@@ -1,0 +1,170 @@
+<?php
+namespace ShoppingFeed\Sdk\Test\Api\Catalog;
+
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\RequestInterface;
+use ShoppingFeed\Sdk;
+
+class PricingUpdateTest extends TestCase
+{
+    /**
+     * @var array
+     */
+    private $operations = [
+        'abc123'  => 1.20,
+        'abc1234' => 2.17,
+        'abc1235' => 3.53,
+    ];
+
+    public function testConstructWithOperations()
+    {
+        $instance   = new Sdk\Api\Catalog\PricingUpdate($this->operations);
+        $reflection = new \ReflectionClass($instance);
+        $property   = $reflection->getProperty('operations');
+        $property->setAccessible(true);
+
+        $result = [];
+        foreach ($this->operations as $reference => $price) {
+            $result[$reference] = compact('reference', 'price');
+        }
+
+        $this->assertEquals($result, $property->getValue($instance));
+
+    }
+
+    public function testAdd()
+    {
+        $instance   = new Sdk\Api\Catalog\PricingUpdate();
+        $reflection = new \ReflectionClass($instance);
+        $property   = $reflection->getProperty('operations');
+        $property->setAccessible(true);
+
+        $result = [];
+        foreach ($this->operations as $reference => $price) {
+            $instance->add($reference, $price);
+            $result[$reference] = compact('reference', 'price');
+        }
+
+        $this->assertEquals($result, $property->getValue($instance));
+    }
+
+    public function testExecute()
+    {
+        $link = $this->createMock(Sdk\Hal\HalLink::class);
+        $link
+            ->expects($this->once())
+            ->method('createRequest')
+            ->willReturn(
+                $this->createMock(RequestInterface::class)
+            );
+
+        $instance = $this
+            ->getMockBuilder(Sdk\Api\Catalog\PricingUpdate::class)
+            ->setConstructorArgs([$this->operations])
+            ->setMethods(['getPoolSize'])
+            ->getMock();
+
+        $instance
+            ->expects($this->once())
+            ->method('getPoolSize')
+            ->willReturn(10);
+
+        $link
+            ->expects($this->once())
+            ->method('batchSend')
+            ->with(
+                [$this->createMock(RequestInterface::class)],
+                function (Sdk\Hal\HalResource $resource) use (&$resources) {
+                    array_push($resources, ...$resource->getResources('pricing'));
+                },
+                null,
+                [],
+                10
+            );
+
+        $this->assertInstanceOf(
+            Sdk\Api\Catalog\PricingCollection::class,
+            $instance->execute($link)
+        );
+    }
+
+    public function testBatchProcessor()
+    {
+        $requests = [];
+        $request  = $this->createMock(RequestInterface::class);
+        $link     = $this->createMock(Sdk\Hal\HalLink::class);
+        $instance = new Sdk\Api\Catalog\PricingUpdate(['ref1' => 1]);
+
+        $link
+            ->expects($this->once())
+            ->method('createRequest')
+            ->with('PUT', [], ['pricing' => ['data']])
+            ->willReturn($request);
+
+        $reflexion       = new \ReflectionClass($instance);
+        $reflexionMethod = $reflexion->getMethod('createBatchProcessorCallback');
+        $reflexionMethod->setAccessible(true);
+
+        $callable = $reflexionMethod->invokeArgs($instance, [$link, &$requests]);
+
+        $this->assertInternalType(\PHPUnit_Framework_Constraint_IsType::TYPE_CALLABLE, $callable);
+
+        $callable(['data']);
+
+        $this->assertEquals($request, $requests[0]);
+    }
+
+    public function testSuccessCallback()
+    {
+        $resources = [];
+        $resource  = $this->createMock(Sdk\Hal\HalResource::class);
+        $instance  = new Sdk\Api\Catalog\PricingUpdate(['ref1' => 1]);
+
+        $resource
+            ->expects($this->once())
+            ->method('getResources')
+            ->with('pricing')
+            ->willReturn([
+                $this->createMock(Sdk\Hal\HalResource::class),
+                $this->createMock(Sdk\Hal\HalResource::class),
+            ]);
+
+        $reflexion       = new \ReflectionClass($instance);
+        $reflexionMethod = $reflexion->getMethod('createSuccessCallback');
+        $reflexionMethod->setAccessible(true);
+
+        $callable = $reflexionMethod->invokeArgs($instance, [&$resources]);
+
+        $this->assertInternalType(\PHPUnit_Framework_Constraint_IsType::TYPE_CALLABLE, $callable);
+
+        $callable($resource);
+
+        $this->assertEquals($resource, $resources[0]);
+    }
+
+    public function testSuccessCallbackWithNoInvetoryReturned()
+    {
+        $resources = [];
+        $resource  = $this->createMock(Sdk\Hal\HalResource::class);
+        $instance  = new Sdk\Api\Catalog\PricingUpdate(['ref1' => 1]);
+
+        $resource
+            ->expects($this->once())
+            ->method('getResources')
+            ->with('pricing')
+            ->willReturn([]);
+
+        $reflexion       = new \ReflectionClass($instance);
+        $reflexionMethod = $reflexion->getMethod('createSuccessCallback');
+        $reflexionMethod->setAccessible(true);
+
+        $callable = $reflexionMethod->invokeArgs($instance, [&$resources]);
+
+        $this->assertInternalType(\PHPUnit_Framework_Constraint_IsType::TYPE_CALLABLE, $callable);
+
+        $callable($resource);
+
+        $this->assertInternalType('array', $resources);
+        $this->assertEmpty($resources);
+    }
+}


### PR DESCRIPTION
### Reason for this PR
Add catalog pricing API

### What does the PR do
Add domain and resources to access catalog pricing api to fetch and update pricing on catalog.

### How to test
Set the variable token and productRef and run this test script with `docker-compose run sf-php-sdk-dev php test.php` : 
```php
<?php

include 'vendor/autoload.php';

date_default_timezone_set('Europe/Paris');

$token      = '[TOKEN]';
$productRef = '[PRODUCT REF]';

$credential = new \ShoppingFeed\Sdk\Credential\Token($token);

$clientOptions = new \ShoppingFeed\Sdk\Client\ClientOptions();
$clientOptions->setBaseUri('http://api.shopping-feed.lan');

$session = \ShoppingFeed\Sdk\Client\Client::createSession($credential, $clientOptions);

echo "SESSION : " . $session->getLogin() . "\n\n";

/***** STORE *****/
$store = $session->getMainStore();
echo "STORE : " . $store->getName() . ' (' . $store->getId() . ")\n\n";

/***** PRICING *****/
$pricingApi = $store->getPricingApi();
foreach ($pricingApi->getPage(['page' => 1]) as $i => $pricing) {
    /** @var \ShoppingFeed\Sdk\Api\Catalog\PricingResource $pricing */
    echo "PRICING : " . $pricing->getReference() . ' (' . $pricing->getPrice() . ')' . "\n";
    if ($i > 5) {
        break;
    }
}
$pricingResource = $pricingApi->getByReference($productRef);
echo "PRICING price : " . $pricingResource->getPrice() . "\n";

$pricingUpdate = new \ShoppingFeed\Sdk\Api\Catalog\PricingUpdate();
$pricingUpdate->add($productRef, $pricingResource->getPrice() + 1.1);
$pricingApi->execute($pricingUpdate);

echo "PRICING updated : " . $pricingApi->getByReference($productRef)->getPrice() . "\n\n";
```


