### PR TITLE
Retrieve additional fields

### DIFF
--- a/src/Api/Order/OrderResource.php
+++ b/src/Api/Order/OrderResource.php
@@ -116,4 +116,12 @@ class OrderResource extends AbstractResource
             $this->resource->getFirstResource('channel')
         );
     }
+
+    /**
+     * @return array
+     */
+    public function getAdditionalFields()
+    {
+        return $this->getProperty('additionalFields');
+    }
 }


### PR DESCRIPTION
Get order additional fields.

Example for Amazon :
```
{
  "is_prime":` "",
  "is_business_order": "1",
  "purchase_order_number": ""
}
```