### PR TITLE
73 - Add order item tax amount

### DIFF
--- a/src/Api/Order/OrderItem.php
+++ b/src/Api/Order/OrderItem.php
@@ -22,15 +22,22 @@ class OrderItem
     private $unitPrice;
 
     /**
+     * @var float
+     */
+    private $taxAmount;
+
+    /**
      * @param string $reference The product's reference
      * @param int    $quantity  Number product's occurrence in cart
      * @param float  $price     The price for a single unit of the reference (not price * quantity)
+     * @param float  $taxAmount The tax amount of the item price
      */
-    public function __construct($reference, $quantity, $price)
+    public function __construct($reference, $quantity, $price, $taxAmount)
     {
         $this->reference = $reference;
         $this->quantity  = $quantity;
         $this->unitPrice = $price;
+        $this->taxAmount = $taxAmount;
     }
 
     /**
@@ -58,6 +65,14 @@ class OrderItem
     }
 
     /**
+     * @return float
+     */
+    public function getTaxAmount()
+    {
+        return $this->taxAmount;
+    }
+
+    /**
      * @return float|int
      */
     public function getTotalPrice()
@@ -73,7 +88,8 @@ class OrderItem
         return [
             'reference' => $this->getReference(),
             'quantity'  => $this->getQuantity(),
-            'price'     => $this->getUnitPrice()
+            'price'     => $this->getUnitPrice(),
+            'taxAmount' => $this->getTaxAmount(),
         ];
     }
 }

--- a/src/Api/Order/OrderItemCollection.php
+++ b/src/Api/Order/OrderItemCollection.php
@@ -1,8 +1,6 @@
 <?php
 namespace ShoppingFeed\Sdk\Api\Order;
 
-use Traversable;
-
 class OrderItemCollection implements \Countable, \IteratorAggregate
 {
     /**
@@ -19,7 +17,9 @@ class OrderItemCollection implements \Countable, \IteratorAggregate
     {
         $instance = new self;
         foreach ($items as $item) {
-            $instance->add(new OrderItem($item['reference'], $item['quantity'], $item['price']));
+            $instance->add(
+                new OrderItem($item['reference'], $item['quantity'], $item['price'], $item['taxAmount'])
+            );
         }
 
         return $instance;

--- a/src/Hal/HalLink.php
+++ b/src/Hal/HalLink.php
@@ -109,13 +109,15 @@ class HalLink
 
     /**
      * @param $path
+     * @param $variables
      *
      * @return HalLink
      */
-    public function withAddedHref($path)
+    public function withAddedHref($path, $variables = [])
     {
         $instance       = clone $this;
-        $instance->href = rtrim($instance->href, '/') . '/' . ltrim($path, '/');
+        $instance->href = rtrim($instance->getUri($variables), '/') .
+                          '/' . ltrim($path, '/');
 
         return $instance;
     }

--- a/tests/unit/Api/Order/OrderItemCollectionTest.php
+++ b/tests/unit/Api/Order/OrderItemCollectionTest.php
@@ -8,12 +8,14 @@ class OrderItemCollectionTest extends \PHPUnit_Framework_TestCase
         [
             'reference' => 'a',
             'quantity'  => 1,
-            'price'     => 2
+            'price'     => 2,
+            'taxAmount' => 7.99,
         ],
         [
             'reference' => 'b',
             'quantity'  => 2,
-            'price'     => 3
+            'price'     => 3,
+            'taxAmount' => 4.99,
         ]
     ];
 
@@ -36,7 +38,8 @@ class OrderItemCollectionTest extends \PHPUnit_Framework_TestCase
         $firstOne = new OrderItem(
             $this->items[0]['reference'],
             $this->items[0]['quantity'],
-            $this->items[0]['price']
+            $this->items[0]['price'],
+            $this->items[0]['taxAmount']
         );
 
         $this->assertEquals($items[0], $firstOne);
@@ -44,7 +47,8 @@ class OrderItemCollectionTest extends \PHPUnit_Framework_TestCase
         $secondOne = new OrderItem(
             $this->items[1]['reference'],
             $this->items[1]['quantity'],
-            $this->items[1]['price']
+            $this->items[1]['price'],
+            $this->items[1]['taxAmount']
         );
 
         $this->assertEquals($items[1], $secondOne);

--- a/tests/unit/Api/Order/OrderItemTest.php
+++ b/tests/unit/Api/Order/OrderItemTest.php
@@ -11,7 +11,7 @@ class OrderItemTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $this->instance = new OrderItem('a', 2, 9.99);
+        $this->instance = new OrderItem('a', 2, 9.99, 7.99);
     }
 
     public function testGetReference()
@@ -26,7 +26,12 @@ class OrderItemTest extends \PHPUnit_Framework_TestCase
 
     public function testGetUnitPrice()
     {
-        $this->assertSame(9.99, $this->instance->getUnitPrice(), 'Unit Price is the last constructor arg');
+        $this->assertSame(9.99, $this->instance->getUnitPrice(), 'Unit Price is the third constructor arg');
+    }
+
+    public function testGetTaxAmount()
+    {
+        $this->assertSame(7.99, $this->instance->getTaxAmount(), 'TaxAmount is the last constructor arg');
     }
 
     public function testGetTotalPriceWithComputeRowPrice()

--- a/tests/unit/Api/Order/OrderResourceTest.php
+++ b/tests/unit/Api/Order/OrderResourceTest.php
@@ -93,6 +93,7 @@ class OrderResourceTest extends Sdk\Test\Api\AbstractResourceTest
                 [
                     'reference' => 'a',
                     'price'     => 9.99,
+                    'taxAmount' => 7.99,
                     'quantity'  => 1,
                 ],
             ],

--- a/tests/unit/Api/Store/StoreResourceTest.php
+++ b/tests/unit/Api/Store/StoreResourceTest.php
@@ -81,4 +81,21 @@ class StoreResourceTest extends Sdk\Test\Api\AbstractResourceTest
 
         $this->assertInstanceOf(Sdk\Api\Order\OrderDomain::class, $instance->getOrderApi());
     }
+
+    public function testGetPricingApi()
+    {
+        /** @var Sdk\Hal\HalResource|\PHPUnit_Framework_MockObject_MockObject $halResource */
+        $halResource = $this->createMock(Sdk\Hal\HalResource::class);
+        $halResource
+            ->expects($this->once())
+            ->method('getLink')
+            ->with('pricing')
+            ->willReturn(
+                $this->createMock(Sdk\Hal\HalLink::class)
+            );
+
+        $instance = new Sdk\Api\Store\StoreResource($halResource);
+
+        $this->assertInstanceOf(Sdk\Api\Catalog\PricingDomain::class, $instance->getPricingApi());
+    }
 }


### PR DESCRIPTION
### Link to the issue
Resolve #73 

### Reason for this PR
Adding access to order item property `taxAmount`

### What does the PR do

- Add access to taxAmount
- Fix a bug when accessing one entity when having a templated link
- Add missing UT

### How to test
1. Choose a client and one of his order
2. Set the token and orderId you want to retreive in the vars in the following script
3. Run the script `docker-compose run sf-php-sdk-dev php test.php` you should see at the end an output like `[ORDER ITEM ID] > [TAX AMOUNT]`
```php
include 'vendor/autoload.php';

date_default_timezone_set('Europe/Paris');

$userToken = '[USER TOKEN]';
$orderId   = [ID ORDER];

$credential    = new \ShoppingFeed\Sdk\Credential\Token($userToken);
$clientOptions = new \ShoppingFeed\Sdk\Client\ClientOptions();
$clientOptions->setBaseUri('http://api.shopping-feed.lan');

$session = \ShoppingFeed\Sdk\Client\Client::createSession($credential, $clientOptions);
$store   = $session->getMainStore();

$orderDomain = $store->getOrderApi();
$order       = $orderDomain->getOne($orderId);

foreach ($order->getItems() as $item) {
    echo $item->getReference() . ' > ' . $item->getTaxAmount() . PHP_EOL;
}
```

