### PR TITLE
Refund Support #77

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+v0.2.7
+======
+
+### Added
+
+- `OrderOperation` : Adding access to refund operation API #81
+
+### Removed
+
+- On the refuse operation, the `$refund` parameter has been removed has it is not used by the API anymore
+
 v0.2.6
 ======
 

--- a/docs/development/coding-standards.md
+++ b/docs/development/coding-standards.md
@@ -59,3 +59,6 @@ Here is a description and links to documentation to help follow them :
   [WhiteSpace/OperatorSpacing](https://github.com/squizlabs/PHP_CodeSniffer/blob/master/src/Standards/Squiz/Sniffs/WhiteSpace/OperatorSpacingSniff.php),
   [WhiteSpace/ScopeClosingBrace](https://github.com/squizlabs/PHP_CodeSniffer/blob/master/src/Standards/Squiz/Sniffs/WhiteSpace/ScopeClosingBraceSniff.php),
   [WhiteSpace/SuperfluousWhitespace](https://github.com/squizlabs/PHP_CodeSniffer/blob/master/src/Standards/Squiz/Sniffs/WhiteSpace/SuperfluousWhitespaceSniff.php),
+  
+  [Squiz/ArrayDeclarationSniff:NoCommaAfterLast,CommaAfterLast,FirstValueNoNewline](https://github.com/squizlabs/PHP_CodeSniffer/blob/master/src/Standards/Squiz/Sniffs/Arrays/ArrayDeclarationSniff.php)
+  

--- a/docs/manual/resources/order.md
+++ b/docs/manual/resources/order.md
@@ -94,6 +94,7 @@ $operation
     ->refuse('ref4', 'amazon')
     ->ship('ref5', 'amazon')
     ->cancel('ref3', 'amazon');
+    ->refund('ref6', 'amazon');
 
 $ticketCollection = $orderApi->execute($operation);
 
@@ -188,10 +189,20 @@ The refund operation accepts 4 parameters :
 Example :
 
 ```php
+$products = [
+  [
+      'reference' => 'abc123',
+      'quantity'  => 1,
+  ],
+  [
+      'reference' => 'abc456',
+      'quantity'  => 2,
+  ],
+];
 $operation = new \ShoppingFeed\Sdk\Api\Order\OrderOperation();
 $operation
-    ->refund('ref1', 'amazon')
-    ->refund('ref2', 'amazon', true, ['itemref1' => 1, 'itemref2' => 2]);
+    ->refund('orderRef1', 'amazon')
+    ->refund('orderRef2', 'amazon', true, $products);
 
 $orderApi->execute($operation);
 ```

--- a/docs/manual/resources/order.md
+++ b/docs/manual/resources/order.md
@@ -145,15 +145,13 @@ $orderApi->execute($operation);
 The refuse operation accepts 3 parameters :
 1. [mandatory] `$reference` : Order reference (eg: 'reference1') 
 2. [mandatory] `$channelName` : The channel where the order is from (eg: 'amazon') 
-3. [optional] `$refund` : Item references to refund (eq: `['itemref1', 'itemref2']`) 
 
 Example :
 
 ```php
 $operation = new \ShoppingFeed\Sdk\Api\Order\OrderOperation();
 $operation
-    ->refuse('ref1', 'amazon')
-    ->refuse('ref2', 'amazon', ['itemref1', 'itemref2']);
+    ->refuse('ref1', 'amazon');
 
 $orderApi->execute($operation);
 ```

--- a/docs/manual/resources/order.md
+++ b/docs/manual/resources/order.md
@@ -178,6 +178,26 @@ $operation
 
 $orderApi->execute($operation);
 ```
+
+### Refund
+
+The refund operation accepts 4 parameters :
+1. [mandatory] `$reference` : Order reference (eg: 'reference1') 
+2. [mandatory] `$channelName` : The channel where the order is from (eg: 'amazon') 
+3. [optional] `$shipping` : true if shipping cost need to be refunded, false otherwise (eq: `false`) 
+4. [optional] `$products` : Item references and their quantities to refund (eq: `['itemref1' => 1, 'itemref2' => 2]`) 
+
+Example :
+
+```php
+$operation = new \ShoppingFeed\Sdk\Api\Order\OrderOperation();
+$operation
+    ->refund('ref1', 'amazon')
+    ->refund('ref2', 'amazon', true, ['itemref1' => 1, 'itemref2' => 2]);
+
+$orderApi->execute($operation);
+```
+
 ### Acknowledge
 
 To acknowledge the good reception of an order, you need the following parameters :

--- a/src/Api/Order/OrderOperation.php
+++ b/src/Api/Order/OrderOperation.php
@@ -17,6 +17,7 @@ class OrderOperation extends Operation\AbstractBulkOperation
     const TYPE_CANCEL        = 'cancel';
     const TYPE_REFUSE        = 'refuse';
     const TYPE_SHIP          = 'ship';
+    const TYPE_REFUND        = 'refund';
     const TYPE_ACKNOWLEDGE   = 'acknowledge';
     const TYPE_UNACKNOWLEDGE = 'unacknowledge';
 
@@ -28,6 +29,7 @@ class OrderOperation extends Operation\AbstractBulkOperation
         self::TYPE_CANCEL,
         self::TYPE_REFUSE,
         self::TYPE_SHIP,
+        self::TYPE_REFUND,
         self::TYPE_ACKNOWLEDGE,
         self::TYPE_UNACKNOWLEDGE,
     ];
@@ -114,19 +116,17 @@ class OrderOperation extends Operation\AbstractBulkOperation
      *
      * @param string $reference   Order reference
      * @param string $channelName Channel to notify
-     * @param array  $refund      Order item reference that will be refunded
      *
      * @return OrderOperation
      *
      * @throws Order\Exception\UnexpectedTypeException
      */
-    public function refuse($reference, $channelName, $refund = [])
+    public function refuse($reference, $channelName)
     {
         $this->addOperation(
             $reference,
             $channelName,
-            OrderOperation::TYPE_REFUSE,
-            compact('refund')
+            OrderOperation::TYPE_REFUSE
         );
 
         return $this;
@@ -318,5 +318,29 @@ class OrderOperation extends Operation\AbstractBulkOperation
         }
 
         $this->operations[$type][] = array_merge(compact('reference', 'channelName'), $data);
+    }
+
+    /**
+     * Notify market place of order refund
+     *
+     * @param string $reference   Order reference
+     * @param string $channelName Channel to notify
+     * @param bool   $shipping    True to refund shipping costs
+     * @param array  $products    Order item reference and quantities that will be refunded
+     *
+     * @return OrderOperation
+     *
+     * @throws Order\Exception\UnexpectedTypeException
+     */
+    public function refund($reference, $channelName, $shipping = true, $products = [])
+    {
+        $this->addOperation(
+            $reference,
+            $channelName,
+            OrderOperation::TYPE_REFUND,
+            ['refund' => compact('shipping', 'products')]
+        );
+
+        return $this;
     }
 }

--- a/src/Api/Order/OrderOperation.php
+++ b/src/Api/Order/OrderOperation.php
@@ -163,8 +163,8 @@ class OrderOperation extends Operation\AbstractBulkOperation
     /**
      * Unacknowledge order reception
      *
-     * @param string $reference     The channel's order reference
-     * @param string $channelName   The channel's name
+     * @param string $reference   The channel's order reference
+     * @param string $channelName The channel's name
      *
      * @return OrderOperation
      *

--- a/src/Api/Order/OrderOperation.php
+++ b/src/Api/Order/OrderOperation.php
@@ -56,7 +56,7 @@ class OrderOperation extends Operation\AbstractBulkOperation
         $this->addOperation(
             $reference,
             $channelName,
-            OrderOperation::TYPE_ACCEPT,
+            self::TYPE_ACCEPT,
             compact('reason')
         );
 
@@ -79,7 +79,7 @@ class OrderOperation extends Operation\AbstractBulkOperation
         $this->addOperation(
             $reference,
             $channelName,
-            OrderOperation::TYPE_CANCEL,
+            self::TYPE_CANCEL,
             compact('reason')
         );
 
@@ -104,7 +104,7 @@ class OrderOperation extends Operation\AbstractBulkOperation
         $this->addOperation(
             $reference,
             $channelName,
-            OrderOperation::TYPE_SHIP,
+            self::TYPE_SHIP,
             compact('carrier', 'trackingNumber', 'trackingLink')
         );
 
@@ -126,7 +126,7 @@ class OrderOperation extends Operation\AbstractBulkOperation
         $this->addOperation(
             $reference,
             $channelName,
-            OrderOperation::TYPE_REFUSE
+            self::TYPE_REFUSE
         );
 
         return $this;
@@ -153,7 +153,7 @@ class OrderOperation extends Operation\AbstractBulkOperation
         $this->addOperation(
             $reference,
             $channelName,
-            OrderOperation::TYPE_ACKNOWLEDGE,
+            self::TYPE_ACKNOWLEDGE,
             compact('status', 'storeReference', 'acknowledgedAt', 'message')
         );
 
@@ -176,7 +176,7 @@ class OrderOperation extends Operation\AbstractBulkOperation
         $this->addOperation(
             $reference,
             $channelName,
-            OrderOperation::TYPE_UNACKNOWLEDGE
+            self::TYPE_UNACKNOWLEDGE
         );
 
         return $this;
@@ -337,7 +337,7 @@ class OrderOperation extends Operation\AbstractBulkOperation
         $this->addOperation(
             $reference,
             $channelName,
-            OrderOperation::TYPE_REFUND,
+            self::TYPE_REFUND,
             ['refund' => compact('shipping', 'products')]
         );
 

--- a/src/Api/Order/OrderTicketCollection.php
+++ b/src/Api/Order/OrderTicketCollection.php
@@ -62,7 +62,7 @@ class OrderTicketCollection extends Task\TicketCollection
     }
 
     /**
-     * Get ticket for accepted reference
+     * Get ticket for refused reference
      *
      * @param $reference
      *
@@ -76,6 +76,25 @@ class OrderTicketCollection extends Task\TicketCollection
             [
                 'reference' => $reference,
                 'operation' => OrderOperation::TYPE_REFUSE,
+            ]
+        );
+    }
+
+    /**
+     * Get ticket for refunded reference
+     *
+     * @param $reference
+     *
+     * @return Task\TicketResource[]
+     *
+     * @throws Order\Exception\TicketNotFoundException
+     */
+    public function getRefunded($reference = null)
+    {
+        return $this->findTickets(
+            [
+                'reference' => $reference,
+                'operation' => OrderOperation::TYPE_REFUND,
             ]
         );
     }

--- a/src/Http/UriTemplate.php
+++ b/src/Http/UriTemplate.php
@@ -30,13 +30,15 @@ class UriTemplate
     ];
 
     /** @var array Delimiters */
-    private static $delims = [':', '/', '?', '#', '[', ']', '@', '!', '$',
-        '&', '\'', '(', ')', '*', '+', ',', ';', '='];
+    private static $delims = [
+        ':', '/', '?', '#', '[', ']', '@', '!', '$', '&', '\'', '(', ')', '*', '+', ',', ';', '=',
+    ];
 
     /** @var array Percent encoded delimiters */
-    private static $delimsPct = ['%3A', '%2F', '%3F', '%23', '%5B', '%5D',
-        '%40', '%21', '%24', '%26', '%27', '%28', '%29', '%2A', '%2B', '%2C',
-        '%3B', '%3D'];
+    private static $delimsPct = [
+        '%3A', '%2F', '%3F', '%23', '%5B', '%5D', '%40', '%21', '%24', '%26', '%27', '%28', '%29', '%2A', '%2B', '%2C',
+        '%3B', '%3D',
+    ];
 
     public function expand($template, array $variables)
     {

--- a/tests/unit/Api/Order/OrderOperationTest.php
+++ b/tests/unit/Api/Order/OrderOperationTest.php
@@ -424,7 +424,8 @@ class OrderOperationTest extends TestCase
                     'refund' => [
                         'shipping' => true,
                         'products' => [
-                            'item1' => 1, 'item2' => 2
+                            ['reference' => 'item1', 'quantity' => 1],
+                            ['reference' => 'item2', 'quantity' => 2],
                         ]
                     ]
                 ]
@@ -436,7 +437,10 @@ class OrderOperationTest extends TestCase
                 'ref1',
                 'amazon',
                 true,
-                ['item1' => 1, 'item2' => 2]
+                [
+                    ['reference' => 'item1', 'quantity' => 1],
+                    ['reference' => 'item2', 'quantity' => 2],
+                ]
             )
         );
     }

--- a/tests/unit/Api/Order/OrderOperationTest.php
+++ b/tests/unit/Api/Order/OrderOperationTest.php
@@ -119,16 +119,14 @@ class OrderOperationTest extends TestCase
             ->with(
                 'ref1',
                 'amazon',
-                Sdk\Api\Order\OrderOperation::TYPE_REFUSE,
-                ['refund' => ['item1', 'item2']]
+                Sdk\Api\Order\OrderOperation::TYPE_REFUSE
             );
 
         $this->assertInstanceOf(
             Sdk\Api\Order\OrderOperation::class,
             $instance->refuse(
                 'ref1',
-                'amazon',
-                ['item1', 'item2']
+                'amazon'
             )
         );
     }
@@ -403,5 +401,43 @@ class OrderOperationTest extends TestCase
 
         $this->assertEquals($resource, $resources[0]);
         $this->assertEquals(count($requests), $refIndex);
+    }
+
+    /**
+     * @throws \Exception
+     */
+    public function testRefundOperation()
+    {
+        $instance = $this
+            ->getMockBuilder(Sdk\Api\Order\OrderOperation::class)
+            ->setMethods(['addOperation'])
+            ->getMock();
+
+        $instance
+            ->expects($this->once())
+            ->method('addOperation')
+            ->with(
+                'ref1',
+                'amazon',
+                Sdk\Api\Order\OrderOperation::TYPE_REFUND,
+                [
+                    'refund' => [
+                        'shipping' => true,
+                        'products' => [
+                            'item1' => 1, 'item2' => 2
+                        ]
+                    ]
+                ]
+            );
+
+        $this->assertInstanceOf(
+            Sdk\Api\Order\OrderOperation::class,
+            $instance->refund(
+                'ref1',
+                'amazon',
+                true,
+                ['item1' => 1, 'item2' => 2]
+            )
+        );
     }
 }

--- a/tests/unit/Api/Order/OrderOperationTest.php
+++ b/tests/unit/Api/Order/OrderOperationTest.php
@@ -299,7 +299,7 @@ class OrderOperationTest extends TestCase
         );
     }
 
-    public function testAssociationBetweenRefandTicketId()
+    public function testAssociationBetweenRefoundTicketId()
     {
         $expected = [
             'accept' => [

--- a/tests/unit/Api/Order/OrderTicketCollectionTest.php
+++ b/tests/unit/Api/Order/OrderTicketCollectionTest.php
@@ -38,10 +38,6 @@ class OrderTicketCollectionTest extends TestCase
             'ticketId147' => ['orderRef1', 'orderRef2', 'orderRef3'],
             'ticketId258' => ['orderRef4', 'orderRef5', 'orderRef6'],
         ],
-        OrderOperation::TYPE_ACKNOWLEDGE => [
-            'ticketId369' => ['orderRef1', 'orderRef2', 'orderRef3'],
-            'ticketId486' => ['orderRef4', 'orderRef5', 'orderRef6'],
-        ],
         OrderOperation::TYPE_REFUND => [
             'ticketId239' => ['orderRef1', 'orderRef2', 'orderRef3'],
             'ticketId446' => ['orderRef4', 'orderRef5', 'orderRef6'],

--- a/tests/unit/Api/Order/OrderTicketCollectionTest.php
+++ b/tests/unit/Api/Order/OrderTicketCollectionTest.php
@@ -42,6 +42,10 @@ class OrderTicketCollectionTest extends TestCase
             'ticketId369' => ['orderRef1', 'orderRef2', 'orderRef3'],
             'ticketId486' => ['orderRef4', 'orderRef5', 'orderRef6'],
         ],
+        OrderOperation::TYPE_REFUND => [
+            'ticketId239' => ['orderRef1', 'orderRef2', 'orderRef3'],
+            'ticketId446' => ['orderRef4', 'orderRef5', 'orderRef6'],
+        ],
     ];
 
     public function testFindTicket()
@@ -127,6 +131,25 @@ class OrderTicketCollectionTest extends TestCase
             );
 
         $instance->getRefused('orderRef1');
+    }
+
+    public function testGetRefundedTicket()
+    {
+        /** @var OrderTicketCollection|\PHPUnit_Framework_MockObject_MockObject $instance */
+        $instance = $this
+            ->getMockBuilder(OrderTicketCollection::class)
+            ->setMethods(['findTickets'])
+            ->getMock();
+
+        $instance
+            ->expects($this->once())
+            ->method('findTickets')
+            ->with(['reference' => 'orderRef1', 'operation' => OrderOperation::TYPE_REFUND])
+            ->willReturn(
+                $this->createMock(TicketResource::class)
+            );
+
+        $instance->getRefunded('orderRef1');
     }
 
     public function testGetAcceptedTicket()


### PR DESCRIPTION
### Link to the issue
Refund Support #77

### Reason for this PR
- Prestashop will add the ability to refund orders after shipment

### What does the PR do
- Add Refund operation with SKUs support
- Remove SKUs support in Refuse (not supported by SFeed)

### How to test
See documentation


