### PR TITLE
Cleanup CS

### DIFF
--- a/src/Api/Order/OrderOperationResult.php
+++ b/src/Api/Order/OrderOperationResult.php
@@ -2,7 +2,6 @@
 namespace ShoppingFeed\Sdk\Api\Order;
 
 use ShoppingFeed\Sdk\Api\Task;
-use ShoppingFeed\Sdk\Hal\HalResource;
 
 class OrderOperationResult
 {
@@ -56,7 +55,7 @@ class OrderOperationResult
     }
 
     /**
-     * @var HalResource[] $resources
+     * @var ShoppingFeed\Sdk\Hal\HalResource[] $resources
      */
     private function setBatches(array $resources)
     {

--- a/src/Api/Order/OrderOperationResult.php
+++ b/src/Api/Order/OrderOperationResult.php
@@ -55,7 +55,7 @@ class OrderOperationResult
     }
 
     /**
-     * @var ShoppingFeed\Sdk\Hal\HalResource[] $resources
+     * @var \ShoppingFeed\Sdk\Hal\HalResource[] $resources
      */
     private function setBatches(array $resources)
     {

--- a/src/Hal/HalLink.php
+++ b/src/Hal/HalLink.php
@@ -1,7 +1,6 @@
 <?php
 namespace ShoppingFeed\Sdk\Hal;
 
-use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use ShoppingFeed\Sdk\Http\UriTemplate;
 use ShoppingFeed\Sdk\Resource\Json;
@@ -243,7 +242,7 @@ class HalLink
     }
 
     /**
-     * @param RequestInterface|RequestInterface[] $request
+     * @param Psr\Http\Message\RequestInterface|Psr\Http\Message\RequestInterface[] $request
      * @param array                               $config
      *
      * @return null|HalResource

--- a/src/Hal/HalLink.php
+++ b/src/Hal/HalLink.php
@@ -242,7 +242,7 @@ class HalLink
     }
 
     /**
-     * @param Psr\Http\Message\RequestInterface|Psr\Http\Message\RequestInterface[] $request
+     * @param \Psr\Http\Message\RequestInterface|\Psr\Http\Message\RequestInterface[] $request
      * @param array                               $config
      *
      * @return null|HalResource

--- a/src/Resource/AbstractCollection.php
+++ b/src/Resource/AbstractCollection.php
@@ -2,7 +2,6 @@
 namespace ShoppingFeed\Sdk\Resource;
 
 use ShoppingFeed\Sdk\Hal;
-use Traversable;
 
 abstract class AbstractCollection extends AbstractResource implements \Countable, \IteratorAggregate
 {
@@ -64,7 +63,7 @@ abstract class AbstractCollection extends AbstractResource implements \Countable
     }
 
     /**
-     * @return Traversable
+     * @return \Traversable
      */
     public function getIterator()
     {

--- a/src/Resource/PaginationCriteria.php
+++ b/src/Resource/PaginationCriteria.php
@@ -58,7 +58,6 @@ class PaginationCriteria
         return $this->filters;
     }
 
-
     /**
      * Convert criteria as ready to be added to URL
      *


### PR DESCRIPTION
### Reason for this PR
CI build broken after update of SF CS rules because rule does not read the docblock annotation anymore

### What does the PR do
Cleanup using `vendor/bin/sfcs src --autofix` + manual transfer of NS in docblock

### How to test
No functionnal change.


