### PR TITLE
Do not decode empty response

### DIFF
--- a/src/Hal/HalClient.php
+++ b/src/Hal/HalClient.php
@@ -105,10 +105,24 @@ class HalClient
      */
     public function createResource(ResponseInterface $response)
     {
-        return HalResource::fromArray(
-            $this,
-            Json::decode($response->getBody(), true)
-        );
+        switch ($response->getStatusCode()) {
+            // no content
+            case 204:
+                $data = [];
+                break;
+            // empty responses are accepted for async tasks
+            case 202:
+                $data = [];
+                $body = trim($response->getBody()->getContents());
+                if ($body) {
+                    $data = Json::decode($body, true);
+                }
+                break;
+            default:
+                $data = Json::decode($response->getBody(), true);
+        }
+
+        return HalResource::fromArray($this, $data);
     }
 
     /**

--- a/src/Hal/HalClient.php
+++ b/src/Hal/HalClient.php
@@ -105,21 +105,11 @@ class HalClient
      */
     public function createResource(ResponseInterface $response)
     {
-        switch ($response->getStatusCode()) {
-            // no content
-            case 204:
-                $data = [];
-                break;
-            // empty responses are accepted for async tasks
-            case 202:
-                $data = [];
-                $body = trim($response->getBody()->getContents());
-                if ($body) {
-                    $data = Json::decode($body, true);
-                }
-                break;
-            default:
-                $data = Json::decode($response->getBody(), true);
+        $data = [];
+        $body = trim($response->getBody());
+
+        if ($body) {
+            $data = Json::decode($body, true);
         }
 
         return HalResource::fromArray($this, $data);


### PR DESCRIPTION
### Reason for this PR
When response are empty (204 or potential empty 202), the SDK throw a fatal error

```
PHP Fatal error:  Uncaught InvalidArgumentException: json_decode error: Syntax error in /php-sdk/src/Resource/Json.php:36
```

### What does the PR do

It does not decode (JSON) response when :
- status code is 204
- an empty response is provided on 202 status code


