### PR TITLE
Handle response with empty body

### DIFF
--- a/src/Resource/Json.php
+++ b/src/Resource/Json.php
@@ -31,7 +31,14 @@ class Json
      */
     public static function decode($json, $assoc = false)
     {
+        $json = (string) $json;
+
+        if ('' === $json) {
+            return null;
+        }
+
         $content = json_decode($json, $assoc);
+
         if (JSON_ERROR_NONE !== json_last_error()) {
             throw new \InvalidArgumentException(
                 'json_decode error: ' . json_last_error_msg()

--- a/src/Resource/PaginationCriteria.php
+++ b/src/Resource/PaginationCriteria.php
@@ -58,7 +58,6 @@ class PaginationCriteria
         return $this->filters;
     }
 
-
     /**
      * Convert criteria as ready to be added to URL
      *

--- a/tests/unit/Resource/JsonTest.php
+++ b/tests/unit/Resource/JsonTest.php
@@ -23,6 +23,11 @@ class JsonTest extends TestCase
         $this->assertEquals(json_decode($this->json), Json::decode($this->json));
     }
 
+    public function testDecodeEmptyString()
+    {
+        $this->assertNull(Json::decode(''));
+    }
+
     public function testThrowDecodeException()
     {
         $this->expectException(\InvalidArgumentException::class);


### PR DESCRIPTION
### Reason for this PR
When response return an empty body the json decode throw an InvalidArgumentException.

![empty_string_decode](https://user-images.githubusercontent.com/10771538/85692984-24825800-b6d6-11ea-9ee6-30bb2fffaac5.png)

### What does the PR do
The \Json::decode() method will return null when an empty string is provided instead of throwing exception.

### How to test
See added unit test.


