### PR TITLE
Handle body for DELETE request

### DIFF
--- a/src/Hal/HalLink.php
+++ b/src/Hal/HalLink.php
@@ -265,7 +265,7 @@ class HalLink
         $method  = strtoupper($method);
         $headers = [];
 
-        if (in_array($method, ['POST', 'PUT', 'PATCH', 'DELETE'])) {
+        if (null !== $body && in_array($method, ['POST', 'PUT', 'PATCH', 'DELETE'])) {
             $headers['Content-Type'] = 'application/json';
             $body                    = Json::encode($body);
         }

--- a/src/Hal/HalLink.php
+++ b/src/Hal/HalLink.php
@@ -253,9 +253,9 @@ class HalLink
     }
 
     /**
-     * @param       $method
-     * @param array $variables
-     * @param array $body
+     * @param string $method
+     * @param array  $variables
+     * @param mixed  $body
      *
      * @return \Psr\Http\Message\RequestInterface
      */
@@ -265,7 +265,7 @@ class HalLink
         $method  = strtoupper($method);
         $headers = [];
 
-        if (null !== $body && in_array($method, ['POST', 'PUT', 'PATCH', 'DELETE'])) {
+        if ((null !== $body && '' !== $body) && in_array($method, ['POST', 'PUT', 'PATCH', 'DELETE'])) {
             $headers['Content-Type'] = 'application/json';
             $body                    = Json::encode($body);
         }

--- a/src/Hal/HalLink.php
+++ b/src/Hal/HalLink.php
@@ -265,7 +265,7 @@ class HalLink
         $method  = strtoupper($method);
         $headers = [];
 
-        if (! isset($headers['Content-Type']) && in_array($method, ['POST', 'PUT', 'PATCH'])) {
+        if (in_array($method, ['POST', 'PUT', 'PATCH', 'DELETE'])) {
             $headers['Content-Type'] = 'application/json';
             $body                    = Json::encode($body);
         }

--- a/tests/unit/Hal/HalLinkTest.php
+++ b/tests/unit/Hal/HalLinkTest.php
@@ -127,7 +127,7 @@ class HalLinkTest extends TestCase
                 $this->isType('string'),
                 $uri,
                 ['Content-Type' => 'application/json'],
-                $this->logicalOr($this->isNull(), $this->isType('string'))
+                $this->isType('string')
             )
             ->willReturn(
                 $this->createMock(RequestInterface::class)
@@ -147,6 +147,39 @@ class HalLinkTest extends TestCase
         $instance->createRequest('PUT', [], ['body' => ['id' => 123]]);
         $instance->createRequest('PATCH', [], ['body' => ['id' => 123]]);
         $instance->createRequest('DELETE', [], ['body' => ['id' => 123]]);
+    }
+
+    public function testCreateRequestWithoutContent()
+    {
+        $uri = '/fake/uri';
+
+        $this->client
+            ->expects($this->exactly(4))
+            ->method('createRequest')
+            ->with(
+                $this->isType('string'),
+                $uri,
+                [],
+                $this->isNull()
+            )
+            ->willReturn(
+                $this->createMock(RequestInterface::class)
+            );
+
+        $instance = $this
+            ->getMockBuilder(HalLink::class)
+            ->setConstructorArgs([$this->client, 'http://base.url'])
+            ->setMethods(['getUri'])
+            ->getMock();
+
+        $instance
+            ->method('getUri')
+            ->willReturn($uri);
+
+        $instance->createRequest('POST', []);
+        $instance->createRequest('PUT', []);
+        $instance->createRequest('PATCH', []);
+        $instance->createRequest('DELETE', []);
     }
 
     public function testBatchSend()

--- a/tests/unit/Hal/HalLinkTest.php
+++ b/tests/unit/Hal/HalLinkTest.php
@@ -118,9 +118,17 @@ class HalLinkTest extends TestCase
 
     public function testCreateRequestWithContent()
     {
+        $uri = '/fake/uri';
+
         $this->client
-            ->expects($this->exactly(3))
+            ->expects($this->exactly(4))
             ->method('createRequest')
+            ->with(
+                $this->isType('string'),
+                $uri,
+                ['Content-Type' => 'application/json'],
+                $this->logicalOr($this->isNull(), $this->isType('string'))
+            )
             ->willReturn(
                 $this->createMock(RequestInterface::class)
             );
@@ -132,13 +140,13 @@ class HalLinkTest extends TestCase
             ->getMock();
 
         $instance
-            ->expects($this->exactly(3))
             ->method('getUri')
-            ->willReturn('/fake/uri');
+            ->willReturn($uri);
 
-        $instance->createRequest('POST');
-        $instance->createRequest('PUT');
-        $instance->createRequest('PATCH');
+        $instance->createRequest('POST', [], ['body' => ['id' => 123]]);
+        $instance->createRequest('PUT', [], ['body' => ['id' => 123]]);
+        $instance->createRequest('PATCH', [], ['body' => ['id' => 123]]);
+        $instance->createRequest('DELETE', [], ['body' => ['id' => 123]]);
     }
 
     public function testBatchSend()

--- a/tests/unit/Hal/HalLinkTest.php
+++ b/tests/unit/Hal/HalLinkTest.php
@@ -154,13 +154,11 @@ class HalLinkTest extends TestCase
         $uri = '/fake/uri';
 
         $this->client
-            ->expects($this->exactly(4))
             ->method('createRequest')
             ->with(
                 $this->isType('string'),
                 $uri,
-                [],
-                $this->isNull()
+                []
             )
             ->willReturn(
                 $this->createMock(RequestInterface::class)
@@ -176,10 +174,14 @@ class HalLinkTest extends TestCase
             ->method('getUri')
             ->willReturn($uri);
 
-        $instance->createRequest('POST', []);
-        $instance->createRequest('PUT', []);
-        $instance->createRequest('PATCH', []);
-        $instance->createRequest('DELETE', []);
+        $instance->createRequest('POST', [], null);
+        $instance->createRequest('POST', [], '');
+        $instance->createRequest('PUT', [], null);
+        $instance->createRequest('PUT', [], '');
+        $instance->createRequest('PATCH', [], null);
+        $instance->createRequest('PATCH', [], '');
+        $instance->createRequest('DELETE', [], null);
+        $instance->createRequest('DELETE', [], '');
     }
 
     public function testBatchSend()


### PR DESCRIPTION
### Reason for this PR

Currently if you create a delete request with a body, it does not work.

```php
<?php

$halLink = new HalLink(...);
$halLink->delete([
    'id' => [123, 456, 789]
]);
```

### What does the PR do
This PR allow to use a body with DELETE request.

### How to test
Covered in unit tests


