### PR TITLE
Add supports for Request Method

### DIFF
--- a/src/Hal/HalClient.php
+++ b/src/Hal/HalClient.php
@@ -21,26 +21,23 @@ class HalClient
     /**
      * @param AdapterInterface $httpClient
      */
-    public function __construct(
-        $baseUri,
-        AdapterInterface $httpClient
-    )
+    public function __construct($baseUri, AdapterInterface $httpClient)
     {
         $this->baseUri = $baseUri;
         $this->client  = $httpClient;
     }
 
     /**
-     * @param $token
+     * @param string $token
      *
      * @return HalClient
      */
     public function withToken($token)
     {
-        $httpClient = $this->client->withToken($token);
-        $instance   = new self($this->baseUri, $httpClient);
-
-        return $instance;
+        return new self(
+            $this->baseUri,
+            $this->client->withToken($token)
+        );
     }
 
     /**

--- a/src/Hal/HalResource.php
+++ b/src/Hal/HalResource.php
@@ -4,6 +4,11 @@ namespace ShoppingFeed\Sdk\Hal;
 class HalResource
 {
     /**
+     * @var HalClient
+     */
+    private $client;
+
+    /**
      * @var array
      */
     private $properties = [];
@@ -51,9 +56,10 @@ class HalResource
     public function __construct(HalClient $client, array $properties = [], array $links = [], array $embedded = [])
     {
         $this->properties = $properties;
+        $this->client     = $client;
 
-        $this->createLinks($client, $links);
-        $this->createEmbedded($client, $embedded);
+        $this->createLinks($links);
+        $this->createEmbedded($embedded);
     }
 
     /**
@@ -151,10 +157,17 @@ class HalResource
     }
 
     /**
-     * @param array     $links
-     * @param HalClient $client
+     * @return HalClient
      */
-    private function createLinks(HalClient $client, array $links)
+    public function getClient()
+    {
+        return $this->client;
+    }
+
+    /**
+     * @param array $links
+     */
+    private function createLinks(array $links)
     {
         foreach ($links as $rel => $link) {
             if ($link instanceof HalLink) {
@@ -162,15 +175,14 @@ class HalResource
                 continue;
             }
 
-            $this->links[$rel] = new HalLink($client, $link['href'], $link);
+            $this->links[$rel] = new HalLink($this->client, $link['href'], $link);
         }
     }
 
     /**
-     * @param HalClient $client
-     * @param array     $relations
+     * @param array $relations
      */
-    private function createEmbedded(HalClient $client, array $relations)
+    private function createEmbedded(array $relations)
     {
         foreach ($relations as $name => $resources) {
             if (array_values($resources) !== $resources) {
@@ -178,7 +190,7 @@ class HalResource
             }
 
             foreach ($resources as $index => $resource) {
-                $this->embedded[$name][$index] = static::fromArray($client, $resource);
+                $this->embedded[$name][$index] = static::fromArray($this->client, $resource);
             }
         }
     }

--- a/src/Http/Adapter/AdapterInterface.php
+++ b/src/Http/Adapter/AdapterInterface.php
@@ -56,6 +56,17 @@ interface AdapterInterface
     public function createRequest($method, $uri, array $headers = [], $body = null);
 
     /**
+     * Initiate request and get a response instance.
+     *
+     * @param string $method   Http method
+     * @param string $uri      The URI to call, ex: '/my/uri'
+     * @param array  $options  Options to pass to the http client
+     *
+     * @return Message\ResponseInterface
+     */
+    public function request($method, $uri, array $options = []);
+
+    /**
      * Use the given token in the 'Authorization' header for all request sent via the adapter
      *
      * When the use perform authentication with the SDK, a new session is created, associated to this token.

--- a/src/Http/Adapter/Guzzle6Adapter.php
+++ b/src/Http/Adapter/Guzzle6Adapter.php
@@ -2,6 +2,7 @@
 namespace ShoppingFeed\Sdk\Http\Adapter;
 
 use GuzzleHttp;
+use Psr\Http\Message;
 use Psr\Http\Message\RequestInterface;
 use ShoppingFeed\Sdk\Client;
 use ShoppingFeed\Sdk\Client\ClientOptions;
@@ -61,8 +62,15 @@ class Guzzle6Adapter implements Http\Adapter\AdapterInterface
 
     /**
      * @inheritdoc
-     *
-     * @throws GuzzleHttp\Exception\GuzzleException
+     */
+    public function request($method, $uri, array $options = [])
+    {
+        return $this->client->request($method, $uri, $options);
+    }
+
+
+    /**
+     * @inheritdoc
      */
     public function send(RequestInterface $request, array $options = [])
     {
@@ -90,8 +98,6 @@ class Guzzle6Adapter implements Http\Adapter\AdapterInterface
 
     /**
      * @inheritdoc
-     *
-     * @throws Http\Exception\MissingDependencyException
      */
     public function withToken($token)
     {

--- a/src/Http/Adapter/Guzzle6Adapter.php
+++ b/src/Http/Adapter/Guzzle6Adapter.php
@@ -2,7 +2,6 @@
 namespace ShoppingFeed\Sdk\Http\Adapter;
 
 use GuzzleHttp;
-use Psr\Http\Message;
 use Psr\Http\Message\RequestInterface;
 use ShoppingFeed\Sdk\Client;
 use ShoppingFeed\Sdk\Client\ClientOptions;
@@ -67,7 +66,6 @@ class Guzzle6Adapter implements Http\Adapter\AdapterInterface
     {
         return $this->client->request($method, $uri, $options);
     }
-
 
     /**
      * @inheritdoc

--- a/tests/unit/Hal/HalResourceTest.php
+++ b/tests/unit/Hal/HalResourceTest.php
@@ -208,6 +208,13 @@ class HalResourceTest extends TestCase
         $this->assertInstanceOf(HalResource::class, $resource);
     }
 
+    public function testInnerClientInstanceIsAccessible()
+    {
+        $client = $this->createMock(HalClient::class);
+        $instance = new HalResource($client);
+        $this->assertSame($client, $instance->getClient());
+    }
+
     /**
      * Format embedded data
      *


### PR DESCRIPTION
### Reason for this PR

We need to get more control over how to initialize HTTP request from adapter (ie: body live stream).
From resource, we open a direct access to the HTTP adapter to interact with non HAL resources.

It requires major version update as the HTTP adapter contract is updated 

### What does the PR do

- The pull request add a method to HTTP adapter with the following signature, and implements it with Guzzle6 adapter
- The HalResource expose 

```php
public function request($method, $uri, array $options = []);
```

### How to test
Test covered by PHPUnit.



