### PR TITLE
SFCNT-33 Add catalog domain and operation

### DIFF
--- a/src/Api/Catalog/CatalogDomain.php
+++ b/src/Api/Catalog/CatalogDomain.php
@@ -1,0 +1,74 @@
+<?php
+namespace ShoppingFeed\Sdk\Api\Catalog;
+
+use ShoppingFeed\Sdk\Resource\AbstractDomainResource;
+
+class CatalogDomain extends AbstractDomainResource
+{
+    /**
+     * @var string
+     */
+    protected $resourceClass = CatalogResource::class;
+
+    /**
+     * @var null|CatalogResource
+     */
+    protected $catalog = null;
+
+    public function askForFeedImport($force = null)
+    {
+        $extra = [];
+
+        if ($force) {
+            $extra = [
+                'params' => [
+                    'skipSecurityChecks' => explode(',', $force),
+                ],
+            ];
+        }
+
+        return $this->askForOperation('importFeed', $extra);
+    }
+
+    public function askForClearCache()
+    {
+        return $this->askForOperation('clearCache');
+    }
+
+    protected function askForOperation($operation, $extra = [])
+    {
+        $catalog = $this->getCatalog();
+        if ($catalog) {
+            $operationLink = $catalog->getOperationLink();
+            if ($operationLink) {
+                return $operationLink->post(
+                    array_merge(
+                        [
+                            'operation' => $operation,
+                            'catalogId' => $catalog->getId(),
+                        ],
+                        $extra
+                    )
+                );
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @return CatalogResource|null
+     */
+    public function getCatalog()
+    {
+        if ($this->catalog === null) {
+            $resource = $this->link->get();
+
+            if ($resource) {
+                $this->catalog = new CatalogResource($resource, false);
+            }
+        }
+
+        return $this->catalog;
+    }
+}

--- a/src/Api/Catalog/CatalogDomain.php
+++ b/src/Api/Catalog/CatalogDomain.php
@@ -15,7 +15,17 @@ class CatalogDomain extends AbstractDomainResource
      */
     protected $catalog = null;
 
-    public function askForFeedImport($force = null)
+    /**
+     * @param string|null $force List of comma separated values that are used
+     * in the `importFeed` operation. Allowed values :
+     * - all
+     * - products
+     * - references
+     * - categories
+     * Only certain roles are allowed to use the $force option.
+     * If the role does not allow it, the option is ignored.
+     */
+    public function requestFeedImport($force = null)
     {
         $extra = [];
 
@@ -27,21 +37,21 @@ class CatalogDomain extends AbstractDomainResource
             ];
         }
 
-        return $this->askForOperation('importFeed', $extra);
+        $this->requestOperation('importFeed', $extra);
     }
 
-    public function askForClearCache()
+    public function requestClearCache()
     {
-        return $this->askForOperation('clearCache');
+        $this->requestOperation('clearCache');
     }
 
-    protected function askForOperation($operation, $extra = [])
+    protected function requestOperation($operation, $extra = [])
     {
         $catalog = $this->getCatalog();
         if ($catalog) {
             $operationLink = $catalog->getOperationLink();
             if ($operationLink) {
-                return $operationLink->post(
+                $operationLink->post(
                     array_merge(
                         [
                             'operation' => $operation,
@@ -52,8 +62,6 @@ class CatalogDomain extends AbstractDomainResource
                 );
             }
         }
-
-        return null;
     }
 
     /**

--- a/src/Api/Catalog/CatalogResource.php
+++ b/src/Api/Catalog/CatalogResource.php
@@ -1,0 +1,17 @@
+<?php
+namespace ShoppingFeed\Sdk\Api\Catalog;
+
+use ShoppingFeed\Sdk\Resource\AbstractResource;
+
+class CatalogResource extends AbstractResource
+{
+    public function getOperationLink()
+    {
+        return $this->resource->getLink('operation');
+    }
+
+    public function getId()
+    {
+        return $this->getProperty('id');
+    }
+}

--- a/src/Api/Store/StoreResource.php
+++ b/src/Api/Store/StoreResource.php
@@ -101,4 +101,14 @@ class StoreResource extends AbstractResource
             $this->resource->getLink('ticket')
         );
     }
+
+    /**
+     * @return Catalog\CatalogDomain
+     */
+    public function getCatalogApi()
+    {
+        return new Catalog\CatalogDomain(
+            $this->resource->getLink('catalog')
+        );
+    }
 }

--- a/tests/unit/Api/Catalog/CatalogDomainTest.php
+++ b/tests/unit/Api/Catalog/CatalogDomainTest.php
@@ -1,0 +1,93 @@
+<?php
+namespace ShoppingFeed\Sdk\Test\Api\Catalog;
+
+use PHPUnit\Framework\TestCase;
+use ShoppingFeed\Sdk;
+
+class CatalogDomainTest extends TestCase
+{
+    public function testGetCatalog()
+    {
+        $link      = $this->createMock(Sdk\Hal\HalLink::class);
+        $resource  = $this->createMock(Sdk\Hal\HalResource::class);
+        $link
+            ->expects($this->once())
+            ->method('get')
+            ->willReturn($resource);
+
+        $instance = new Sdk\Api\Catalog\CatalogDomain($link);
+
+        $this->assertInstanceOf(Sdk\Api\Catalog\CatalogResource::class, $instance->getCatalog());
+    }
+
+    public function testAskForClearCache()
+    {
+        $instance = new Sdk\Api\Catalog\CatalogDomain(
+            $this->configureCatalogResource('clearCache')
+        );
+
+        $instance->askForClearCache();
+    }
+
+    public function testAskForFeedImport()
+    {
+        $instance = new Sdk\Api\Catalog\CatalogDomain(
+            $this->configureCatalogResource('importFeed')
+        );
+
+        $instance->askForFeedImport();
+    }
+
+    public function testAskForFeedImportWithForce()
+    {
+        $instance = new Sdk\Api\Catalog\CatalogDomain(
+            $this->configureCatalogResource('importFeed', [
+                'params'    => [
+                    'skipSecurityChecks' => ['products', 'references']
+                ]
+            ])
+        );
+
+        $instance->askForFeedImport('products,references');
+    }
+
+    protected function configureCatalogResource($operation, $extra = [])
+    {
+        $catalogLink   = $this->createMock(Sdk\Hal\HalLink::class);
+        $operationLink = $this->createMock(Sdk\Hal\HalLink::class);
+        $operationLink
+            ->expects($this->once())
+            ->method('post')
+            ->with(
+                array_merge(
+                    [
+                        'operation' => $operation,
+                        'catalogId' => 123,
+                    ],
+                    $extra
+                )
+            );
+
+        $resource = $this->createMock(Sdk\Hal\HalResource::class);
+
+        $resource
+            ->expects($this->once())
+            ->method('getLink')
+            ->willReturn($operationLink);
+        $resource
+            ->method('hasProperty')
+            ->with('id')
+            ->willReturn(true);
+        $resource
+            ->expects($this->once())
+            ->method('getProperty')
+            ->with('id')
+            ->willReturn(123);
+        $catalogLink
+            ->expects($this->once())
+            ->method('get')
+            ->willReturn($resource);
+
+        return $catalogLink;
+    }
+}

--- a/tests/unit/Api/Catalog/CatalogDomainTest.php
+++ b/tests/unit/Api/Catalog/CatalogDomainTest.php
@@ -26,7 +26,7 @@ class CatalogDomainTest extends TestCase
             $this->configureCatalogResource('clearCache')
         );
 
-        $instance->askForClearCache();
+        $instance->requestClearCache();
     }
 
     public function testAskForFeedImport()
@@ -35,7 +35,7 @@ class CatalogDomainTest extends TestCase
             $this->configureCatalogResource('importFeed')
         );
 
-        $instance->askForFeedImport();
+        $instance->requestFeedImport();
     }
 
     public function testAskForFeedImportWithForce()
@@ -48,7 +48,7 @@ class CatalogDomainTest extends TestCase
             ])
         );
 
-        $instance->askForFeedImport('products,references');
+        $instance->requestFeedImport('products,references');
     }
 
     protected function configureCatalogResource($operation, $extra = [])

--- a/tests/unit/Api/Catalog/CatalogResourceTest.php
+++ b/tests/unit/Api/Catalog/CatalogResourceTest.php
@@ -1,0 +1,33 @@
+<?php
+namespace ShoppingFeed\Sdk\Test\Api\Catalog;
+
+use ShoppingFeed\Sdk;
+
+class CatalogResourceTest extends Sdk\Test\Api\AbstractResourceTest
+{
+    public function setUp()
+    {
+        $this->props = [
+            'id'        => 10,
+            '_links' => [
+                'operation' => 'abc/123'
+            ],
+        ];
+    }
+
+    public function testPropertiesGetters()
+    {
+        $this->initHalResourceProperties();
+
+        $this->halResource
+            ->expects($this->once())
+            ->method('getLink')
+            ->with('operation')
+            ->willReturn('abc/123');
+
+        $instance = new Sdk\Api\Catalog\CatalogResource($this->halResource);
+
+        $this->assertSame($this->props['id'], $instance->getId());
+        $this->assertSame($this->props['_links']['operation'], $instance->getOperationLink());
+    }
+}


### PR DESCRIPTION
### Link to the issue
https://shopping-feed.atlassian.net/browse/SFCNT-33

### Reason for this PR
After having added the link to the catalog domain in [this PR](https://github.com/shoppingflux/api/pull/793), we add the catalog domain & resource here, which allow us to : 
- [get the catalog](https://next.stoplight.io/shopping-feed-1/api/version%2F1.1/catalog.oas2.yml?view=%2Fcatalog%2Fv1catalogget)
- [ask for an operation](https://next.stoplight.io/shopping-feed-1/api/version%2F1.1/catalog.oas2.yml?view=%2Foperation%2Fv1catalog-operationpost)

I'm aware that : 
- these 2 end-points are currently unpublished
- the operation end-point concerns 2 possible operations, one of which is only available for certain roles

But : 
- I'm guessing the catalog end-point will soon be published (and as long as it is not officially published, people, if they use it, will use it at their own risk)
- for the operation end-point, I've opted for the simplest solution (integrate it in the public SDK and let the API decide if the user is allowed or not to carry out the operation, based on his/her role)

### What does the PR do
This PR allows asking for an import using the SDK. This is necessary, so as to refactor the legacy project.

Why not do this in the private SDK (I hear you asking) ? Because asking for an import is something that everyone can do. Sure, the corresponding API end-point is not yet published, but I'm confident it will be soon.

### How to test

If [this PR](https://github.com/shoppingflux/api/pull/793) is not yet merged, please make sure you are on the branch associated with this PR (on the API project) before testing. 

To test, you can use the following script

```php
<?php
include 'vendor/autoload.php';

date_default_timezone_set('Europe/Paris');

$userToken = 'TOKEN'; // replace with a real token

$credential    = new \ShoppingFeed\Sdk\Credential\Token($userToken);
$clientOptions = new \ShoppingFeed\Sdk\Client\ClientOptions();
$clientOptions->setBaseUri('http://api.shopping-feed.lan');

$session = \ShoppingFeed\Sdk\Client\Client::createSession($credential, $clientOptions);
$store   = $session->getMainStore();

$catalogDomain = $store->getCatalogApi();
$catalogDomain->askForFeedImport();
```
and launch it in the command line : 
`php test.php`
(assuming you named the file `test.php`; please launch the command outside the Docker container)

If everything works OK, you should see a new published message on RabbitMQ (local) >> Queues >> `sf.catalog.feed:dispatch`.