### PR TITLE
Add missing properties to store resource

### DIFF
--- a/src/Api/Store/StoreResource.php
+++ b/src/Api/Store/StoreResource.php
@@ -53,6 +53,32 @@ class StoreResource extends AbstractResource
     }
 
     /**
+     * @return string
+     */
+    public function getCurrencyCode()
+    {
+        return $this->getProperty('currency');
+    }
+
+    /**
+     * @return string
+     */
+    public function getEmail()
+    {
+        return $this->getProperty('email');
+    }
+
+    /**
+     * @return \DateTimeImmutable
+     *
+     * @throws \Exception
+     */
+    public function getCreatedAt()
+    {
+        return new \DateTimeImmutable($this->getProperty('createdAt'));
+    }
+
+    /**
      * @return StoreChannelDomain
      */
     public function getChannelApi()

--- a/tests/unit/Api/Store/StoreResourceTest.php
+++ b/tests/unit/Api/Store/StoreResourceTest.php
@@ -8,10 +8,13 @@ class StoreResourceTest extends Sdk\Test\Api\AbstractResourceTest
     public function setUp()
     {
         $this->props = [
-            'id'      => 10,
-            'name'    => 'abc123',
-            'country' => 'FR',
-            'status'  => 'active',
+            'id'        => 10,
+            'name'      => 'abc123',
+            'country'   => 'FR',
+            'status'    => 'active',
+            'email'     => 'zizou@fff.com',
+            'currency'  => 'EUR',
+            'createdAt' => '1998-07-12T20:57:55+00:00',
         ];
     }
 
@@ -25,6 +28,9 @@ class StoreResourceTest extends Sdk\Test\Api\AbstractResourceTest
         $this->assertSame($this->props['name'], $instance->getName());
         $this->assertSame($this->props['country'], $instance->getCountryCode());
         $this->assertSame('active', $instance->getStatus());
+        $this->assertSame($this->props['email'], $instance->getEmail());
+        $this->assertSame($this->props['currency'], $instance->getCurrencyCode());
+        $this->assertEquals(date_create_immutable($this->props['createdAt']), $instance->getCreatedAt());
         $this->assertTrue($instance->isActive());
     }
 


### PR DESCRIPTION
### Reason for this PR
Some store's properties are not available through SDK :
- currency
- email
- createdAt

Documentation : https://developer.shopping-feed.com/store-api/store/v1storeget

### What does the PR do
This PR add access to 'currency', 'email' & 'createdAt' properties in StoreResource

### How to test
Just added the corresponding unit tests.


