### PR TITLE
Add transaction ID to calls made from HalClient

### DIFF
--- a/src/Hal/HalClient.php
+++ b/src/Hal/HalClient.php
@@ -84,6 +84,7 @@ class HalClient
             if (! isset($options['query'])) {
                 $options['query'] = [];
             }
+
             $options['query']['tid'] = $this->transactionId;
         }
 
@@ -101,11 +102,11 @@ class HalClient
      */
     public function batchSend($requests, array $config = [])
     {
-
         if (null !== $this->transactionId) {
             if (! isset($config['options'])) {
                 $config['options'] = [];
             }
+
             if (! isset($config['options']['query'])) {
                 $config['options']['query'] = [];
             }
@@ -128,6 +129,7 @@ class HalClient
             if (! isset($options['query'])) {
                 $options['query'] = [];
             }
+
             $options['query']['tid'] = $this->transactionId;
         }
 

--- a/src/Hal/HalClient.php
+++ b/src/Hal/HalClient.php
@@ -150,7 +150,10 @@ class HalClient
         return $this->client;
     }
 
-    private function injectTransactionId(&$options): void
+    /**
+     * Inject transaction ID in query param of the request is one is available
+     */
+    private function injectTransactionId(&$options)
     {
         if (null !== $this->transactionId) {
             if (! isset($options['query'])) {

--- a/src/Hal/HalClient.php
+++ b/src/Hal/HalClient.php
@@ -80,13 +80,7 @@ class HalClient
      */
     public function request($method, $uri, array $options = [])
     {
-        if (null !== $this->transactionId) {
-            if (! isset($options['query'])) {
-                $options['query'] = [];
-            }
-
-            $options['query']['tid'] = $this->transactionId;
-        }
+        $this->injectTransactionId($options);
 
         return $this->send(
             $this->client->createRequest($method, $uri),
@@ -102,17 +96,11 @@ class HalClient
      */
     public function batchSend($requests, array $config = [])
     {
-        if (null !== $this->transactionId) {
-            if (! isset($config['options'])) {
-                $config['options'] = [];
-            }
-
-            if (! isset($config['options']['query'])) {
-                $config['options']['query'] = [];
-            }
-
-            $config['options']['query']['tid'] = $this->transactionId;
+        if (! isset($config['options'])) {
+            $config['options'] = [];
         }
+
+        $this->injectTransactionId($config['options']);
 
         $this->client->batchSend($requests, $config);
     }
@@ -125,13 +113,7 @@ class HalClient
      */
     public function send(RequestInterface $request, array $options = [])
     {
-        if (null !== $this->transactionId) {
-            if (! isset($options['query'])) {
-                $options['query'] = [];
-            }
-
-            $options['query']['tid'] = $this->transactionId;
-        }
+        $this->injectTransactionId($options);
 
         $response = $this->client->send($request, $options);
         if ($response instanceof ResponseInterface) {
@@ -166,5 +148,16 @@ class HalClient
     public function getAdapter()
     {
         return $this->client;
+    }
+
+    private function injectTransactionId(&$options): void
+    {
+        if (null !== $this->transactionId) {
+            if (! isset($options['query'])) {
+                $options['query'] = [];
+            }
+
+            $options['query']['tid'] = $this->transactionId;
+        }
     }
 }

--- a/src/Hal/HalClient.php
+++ b/src/Hal/HalClient.php
@@ -152,6 +152,8 @@ class HalClient
 
     /**
      * Inject transaction ID in query param of the request is one is available
+     *
+     * @param array &$options Request options to inject tid query param into
      */
     private function injectTransactionId(&$options)
     {

--- a/src/Hal/HalClient.php
+++ b/src/Hal/HalClient.php
@@ -19,6 +19,11 @@ class HalClient
     private $baseUri;
 
     /**
+     * @var null|int
+     */
+    private $transactionId = null;
+
+    /**
      * @param AdapterInterface $httpClient
      */
     public function __construct($baseUri, AdapterInterface $httpClient)
@@ -38,6 +43,19 @@ class HalClient
             $this->baseUri,
             $this->client->withToken($token)
         );
+    }
+
+    /**
+     * @param int $transactionId
+     *
+     * @return HalClient
+     */
+    public function withTransactionId($transactionId)
+    {
+        $instance                = clone $this;
+        $instance->transactionId = $transactionId;
+
+        return $instance;
     }
 
     /**
@@ -62,6 +80,13 @@ class HalClient
      */
     public function request($method, $uri, array $options = [])
     {
+        if (null !== $this->transactionId) {
+            if (! isset($options['query'])) {
+                $options['query'] = [];
+            }
+            $options['query']['tid'] = $this->transactionId;
+        }
+
         return $this->send(
             $this->client->createRequest($method, $uri),
             $options
@@ -76,6 +101,18 @@ class HalClient
      */
     public function batchSend($requests, array $config = [])
     {
+
+        if (null !== $this->transactionId) {
+            if (! isset($config['options'])) {
+                $config['options'] = [];
+            }
+            if (! isset($config['options']['query'])) {
+                $config['options']['query'] = [];
+            }
+
+            $config['options']['query']['tid'] = $this->transactionId;
+        }
+
         $this->client->batchSend($requests, $config);
     }
 
@@ -87,6 +124,13 @@ class HalClient
      */
     public function send(RequestInterface $request, array $options = [])
     {
+        if (null !== $this->transactionId) {
+            if (! isset($options['query'])) {
+                $options['query'] = [];
+            }
+            $options['query']['tid'] = $this->transactionId;
+        }
+
         $response = $this->client->send($request, $options);
         if ($response instanceof ResponseInterface) {
             return $this->createResource($response);

--- a/tests/unit/Hal/HalClientTest.php
+++ b/tests/unit/Hal/HalClientTest.php
@@ -4,7 +4,6 @@ namespace ShoppingFeed\Sdk\Test\Hal;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message;
 use ShoppingFeed\Sdk\Hal;
-use ShoppingFeed\Sdk\Hal\HalResource;
 use ShoppingFeed\Sdk\Http;
 
 class HalClientTest extends TestCase
@@ -195,5 +194,169 @@ class HalClientTest extends TestCase
         $instance   = new Hal\HalClient('http://fake.uri', $httpClient);
 
         $this->assertSame($httpClient, $instance->getAdapter());
+    }
+
+    public function testSendWitTransactionId()
+    {
+        $response = $this->createMock(Message\ResponseInterface::class);
+        $request  = $this->createMock(Message\RequestInterface::class);
+
+        $client = $this->createMock(Http\Adapter\AdapterInterface::class);
+        $client
+            ->expects($this->once())
+            ->method('send')
+            ->with(
+                $request,
+                [
+                    'query' => [
+                        'tid' => 'abc123',
+                    ],
+                ]
+            )
+            ->willReturn($response);
+
+        $instance = new Hal\HalClient('http://fake.uri', $client);
+        $instance = $instance->withTransactionId('abc123');
+
+        $instance->send($request);
+    }
+
+    public function testSendWitTransactionIdCantBeOverride()
+    {
+        $response = $this->createMock(Message\ResponseInterface::class);
+        $request  = $this->createMock(Message\RequestInterface::class);
+
+        $client = $this->createMock(Http\Adapter\AdapterInterface::class);
+        $client
+            ->expects($this->once())
+            ->method('send')
+            ->with(
+                $request,
+                [
+                    'query' => [
+                        'tid' => 'abc123',
+                    ],
+                ]
+            )
+            ->willReturn($response);
+
+        $instance = new Hal\HalClient('http://fake.uri', $client);
+        $instance = $instance->withTransactionId('abc123');
+
+        $instance->send($request, ['query' => ['tid' => 'def456']]);
+    }
+
+    public function testBatchSendWitTransactionId()
+    {
+        $response = $this->createMock(Message\ResponseInterface::class);
+
+        $client = $this->createMock(Http\Adapter\AdapterInterface::class);
+        $client
+            ->expects($this->once())
+            ->method('batchSend')
+            ->with(
+                [],
+                [
+                    'options' => [
+                        'query' => [
+                            'tid' => 'abc123',
+                        ],
+                    ],
+                ]
+            )
+            ->willReturn($response);
+
+        $instance = new Hal\HalClient('http://fake.uri', $client);
+        $instance = $instance->withTransactionId('abc123');
+
+        $instance->batchSend([]);
+    }
+
+    public function testRequestWitTransactionId()
+    {
+        $response = $this->createMock(Message\ResponseInterface::class);
+
+        $client = $this->createMock(Http\Adapter\AdapterInterface::class);
+        $client
+            ->expects($this->once())
+            ->method('createRequest')
+            ->with('GET', '/')
+            ->willReturn($this->createMock(Message\RequestInterface::class));
+        $client
+            ->expects($this->once())
+            ->method('send')
+            ->with(
+                $this->isInstanceOf(Message\RequestInterface::class),
+                [
+                    'query' => [
+                        'tid' => 'abc123',
+                    ],
+                ]
+            )
+            ->willReturn($response);
+
+        $instance = new Hal\HalClient('http://fake.uri', $client);
+        $instance = $instance->withTransactionId('abc123');
+
+        $instance->request('GET', '/');
+    }
+
+    public function testWitTransactionIdInjected()
+    {
+        $response = $this->createMock(Message\ResponseInterface::class);
+
+        $client = $this->createMock(Http\Adapter\AdapterInterface::class);
+        $client
+            ->expects($this->once())
+            ->method('createRequest')
+            ->with('GET', '/')
+            ->willReturn($this->createMock(Message\RequestInterface::class));
+        $client
+            ->expects($this->once())
+            ->method('send')
+            ->with(
+                $this->isInstanceOf(Message\RequestInterface::class),
+                [
+                    'prop1' => 'val1',
+                    'query' => [
+                        'tid' => 'abc123',
+                    ],
+                ]
+            )
+            ->willReturn($response);
+
+        $instance = new Hal\HalClient('http://fake.uri', $client);
+        $instance = $instance->withTransactionId('abc123');
+
+        $instance->request('GET', '/', ['prop1' => 'val1']);
+    }
+
+    public function testWitTransactionIdCantBeOverride()
+    {
+        $response = $this->createMock(Message\ResponseInterface::class);
+
+        $client = $this->createMock(Http\Adapter\AdapterInterface::class);
+        $client
+            ->expects($this->once())
+            ->method('createRequest')
+            ->with('GET', '/')
+            ->willReturn($this->createMock(Message\RequestInterface::class));
+        $client
+            ->expects($this->once())
+            ->method('send')
+            ->with(
+                $this->isInstanceOf(Message\RequestInterface::class),
+                [
+                    'query' => [
+                        'tid' => 'abc123',
+                    ],
+                ]
+            )
+            ->willReturn($response);
+
+        $instance = new Hal\HalClient('http://fake.uri', $client);
+        $instance = $instance->withTransactionId('abc123');
+
+        $instance->request('GET', '/', ['query' => ['tid' => 'def456']]);
     }
 }

--- a/tests/unit/Hal/HalClientTest.php
+++ b/tests/unit/Hal/HalClientTest.php
@@ -196,7 +196,7 @@ class HalClientTest extends TestCase
         $this->assertSame($httpClient, $instance->getAdapter());
     }
 
-    public function testSendWitTransactionId()
+    public function testSendWithTransactionId()
     {
         $response = $this->createMock(Message\ResponseInterface::class);
         $request  = $this->createMock(Message\RequestInterface::class);
@@ -221,7 +221,7 @@ class HalClientTest extends TestCase
         $instance->send($request);
     }
 
-    public function testSendWitTransactionIdCantBeOverride()
+    public function testSendWithTransactionIdCantBeOverride()
     {
         $response = $this->createMock(Message\ResponseInterface::class);
         $request  = $this->createMock(Message\RequestInterface::class);
@@ -246,7 +246,7 @@ class HalClientTest extends TestCase
         $instance->send($request, ['query' => ['tid' => 'def456']]);
     }
 
-    public function testBatchSendWitTransactionId()
+    public function testBatchSendWithTransactionId()
     {
         $response = $this->createMock(Message\ResponseInterface::class);
 
@@ -272,7 +272,7 @@ class HalClientTest extends TestCase
         $instance->batchSend([]);
     }
 
-    public function testRequestWitTransactionId()
+    public function testRequestWithTransactionId()
     {
         $response = $this->createMock(Message\ResponseInterface::class);
 
@@ -301,7 +301,7 @@ class HalClientTest extends TestCase
         $instance->request('GET', '/');
     }
 
-    public function testWitTransactionIdInjected()
+    public function testWithTransactionIdIsInjected()
     {
         $response = $this->createMock(Message\ResponseInterface::class);
 
@@ -331,7 +331,7 @@ class HalClientTest extends TestCase
         $instance->request('GET', '/', ['prop1' => 'val1']);
     }
 
-    public function testWitTransactionIdCantBeOverride()
+    public function testWithTransactionIdCantBeOverride()
     {
         $response = $this->createMock(Message\ResponseInterface::class);
 


### PR DESCRIPTION
### Reason for this PR
We need to be able to retrace all the different call made during a session.

### What does the PR do
In order to be able to regroup the multiple calls of a sessions together we add a transaction id to every request made from one HalClient.
This parameter should be added to all request as a `tid` query param.
This will allow to aggregate multiple call as coming from the same session.

### How to test
1. Install SDK dependencies `composer install`
2. Start a standalone server with this script to test : `php -S localhost:8000 server.php`
```php
<?php
// Log transaction ID received
error_log('Transaction : ' . $_GET['tid'] );

// Output a JSON to avoid HAL error on client
echo json_encode($_GET);

return;
```
3. Run this test script, you should see 4 time the transaction ID in the output of the server log output `php test.php`.
```php
<?php
namespace ShoppingFeed\Sdk;

include __DIR__ . '/vendor/autoload.php';

date_default_timezone_set('Europe/Paris');

$config = [
    'api_url' => 'http://localhost:8000',
];

$options = new Client\ClientOptions();
$options->setBaseUri(
    $config['api_url']
);

$client = new Client\Client($options);
$halClient = $client->getHalClient()->withTransactionId('123456798');

$halClient->request('GET', '/');
$halClient->batchSend([
    new \GuzzleHttp\Psr7\Request('GET', '/'),
    new \GuzzleHttp\Psr7\Request('GET', '/'),
]);
$halClient->send(new \GuzzleHttp\Psr7\Request('GET', '/'));
```




