### PR TITLE
SFCORE-1252: Add access to channel mode property

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         phpv: [ 5.6, 7.1 ]

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "monolog/monolog": "^1.23",
     "guzzlehttp/guzzle": "^6.0",
     "phpunit/phpunit": "^5.0",
-    "shoppingfeed/coding-style-php": "2.1.0",
+    "shoppingfeed/coding-style-php": "~2.1.0",
     "overtrue/phplint": "^1.1"
   },
   "scripts": {

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "monolog/monolog": "^1.23",
     "guzzlehttp/guzzle": "^6.0",
     "phpunit/phpunit": "^5.0",
-    "shoppingfeed/coding-style-php": "^2.0",
+    "shoppingfeed/coding-style-php": "2.1.0",
     "overtrue/phplint": "^1.1"
   },
   "scripts": {

--- a/src/Api/Channel/ChannelResource.php
+++ b/src/Api/Channel/ChannelResource.php
@@ -56,4 +56,12 @@ class ChannelResource extends AbstractResource
     {
         return (array) $this->getProperty('countries', true);
     }
+
+    /**
+     * @return string The channel mode
+     */
+    public function getMode()
+    {
+        return (string) $this->getProperty('mode');
+    }
 }

--- a/tests/unit/Api/Channel/ChannelResourceTest.php
+++ b/tests/unit/Api/Channel/ChannelResourceTest.php
@@ -11,7 +11,8 @@ class ChannelResourceTest extends AbstractResourceTest
         //Set up regular properties
         $this->initHalResourceProperties([
             'id'   => 1,
-            'name' => 'toto'
+            'name' => 'toto',
+            'mode' => 'replace',
         ]);
 
         // Setup image link
@@ -31,6 +32,7 @@ class ChannelResourceTest extends AbstractResourceTest
         $this->assertSame(1, $instance->getId());
         $this->assertSame('toto', $instance->getName());
         $this->assertSame('http://toto.jpg', $instance->getLogoUrl());
+        $this->assertSame('replace', $instance->getMode());
     }
 
     public function testOtherAccessors()


### PR DESCRIPTION
### Reason for this PR
Add channel's mode property is not available through SDK (introduce in this pr https://github.com/shoppingflux/api/pull/1224)

### What does the PR do
This PR add access to 'mode' property in ChannelResource

### How to test
Just added the corresponding unit test.