### PR TITLE
Fix return type compatibility with PHP 8.1

### DIFF
--- a/src/Api/Order/OrderItemCollection.php
+++ b/src/Api/Order/OrderItemCollection.php
@@ -25,6 +25,7 @@ class OrderItemCollection implements \Countable, \IteratorAggregate
         return $instance;
     }
 
+    #[\ReturnTypeWillChange]
     public function count()
     {
         return count($this->items);
@@ -33,6 +34,7 @@ class OrderItemCollection implements \Countable, \IteratorAggregate
     /**
      * @return \ArrayIterator|OrderItem[]
      */
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         return new \ArrayIterator($this->items);

--- a/src/Resource/AbstractCollection.php
+++ b/src/Resource/AbstractCollection.php
@@ -39,6 +39,7 @@ abstract class AbstractCollection extends AbstractResource implements \Countable
     /**
      * @return int
      */
+    #[\ReturnTypeWillChange]
     public function count()
     {
         return count($this->resources);
@@ -65,6 +66,7 @@ abstract class AbstractCollection extends AbstractResource implements \Countable
     /**
      * @return \Traversable
      */
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         return new \ArrayIterator($this->resources);

--- a/src/Resource/PaginatedResourceCollection.php
+++ b/src/Resource/PaginatedResourceCollection.php
@@ -93,6 +93,7 @@ class PaginatedResourceCollection extends AbstractResource implements \IteratorA
     /**
      * @inheritdoc
      */
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         $data = current($this->resource->getAllResources()) ?: [];
@@ -104,6 +105,7 @@ class PaginatedResourceCollection extends AbstractResource implements \IteratorA
     /**
      * @inheritdoc
      */
+    #[\ReturnTypeWillChange]
     public function count()
     {
         return $this->getCurrentCount();

--- a/src/Resource/PaginatedResourceIterator.php
+++ b/src/Resource/PaginatedResourceIterator.php
@@ -19,6 +19,7 @@ class PaginatedResourceIterator implements \IteratorAggregate, \Countable
         $this->paginator = $resource;
     }
 
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         $resource = $this->paginator;
@@ -31,6 +32,7 @@ class PaginatedResourceIterator implements \IteratorAggregate, \Countable
         }
     }
 
+    #[\ReturnTypeWillChange]
     public function count()
     {
         return $this->paginator->getTotalCount();

--- a/src/Resource/ResourceProperties.php
+++ b/src/Resource/ResourceProperties.php
@@ -15,11 +15,13 @@ class ResourceProperties implements \ArrayAccess
         $this->data = $data;
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->data[$offset]);
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         if ($this->offsetExists($offset)) {
@@ -29,11 +31,13 @@ class ResourceProperties implements \ArrayAccess
         return null;
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         throw new Exception\RuntimeException('Resource properties cannot be modified');
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         throw new Exception\RuntimeException('Resource properties cannot be modified');


### PR DESCRIPTION
### Reason for this PR
PHP 8.1 requires overriding internal methods to declare compatible return types.

### What does the PR do
Add a `[ReturnTypeWillChange]` attribute to each method concerned by a deprecation notice (see [PHP migration notes](https://www.php.net/manual/fr/migration81.incompatible.php#migration81.incompatible.core.type-compatibility-internal)).



