### PR TITLE
Fix rejected callback

### DIFF
--- a/src/Http/Adapter/GuzzleHTTPAdapter.php
+++ b/src/Http/Adapter/GuzzleHTTPAdapter.php
@@ -117,12 +117,12 @@ class GuzzleHTTPAdapter implements Http\Adapter\AdapterInterface
      */
     private function createExceptionCallback(callable $callback = null)
     {
-        return function (GuzzleHttp\Exception\RequestException $exception) use ($callback) {
-            if ($exception->hasResponse() && $callback) {
+        return function (GuzzleHttp\Exception\TransferException $exception) use ($callback) {
+            if ($callback && $exception instanceof GuzzleHttp\Exception\RequestException && $exception->hasResponse()) {
                 $halClient = new HalClient($this->options->getBaseUri(), $this);
                 $resource  = $halClient->createResource($exception->getResponse());
 
-                call_user_func($callback, $resource);
+                $callback($resource);
             }
         };
     }


### PR DESCRIPTION
### Reason for this PR
Guzzle ConnectException does no longer extends RequestException. It causes type error when a ConnectException is thrown.

```json
{
  "exception": {
    "message": "ShoppingFeed\\Sdk\\Http\\Adapter\\GuzzleHTTPAdapter::ShoppingFeed\\Sdk\\Http\\Adapter\\{closure}(): Argument #1 ($exception) must be of type GuzzleHttp\\Exception\\RequestException, GuzzleHttp\\Exception\\ConnectException given",
    "class": "TypeError",
    "code": 0,
    "file": "/vendor/shoppingfeed/php-sdk/src/Http/Adapter/GuzzleHTTPAdapter.php",
    "line": 120
  }
}
```

### What does the PR do
Callback now handle Guzzle TransferException

