### PR TITLE
Fix type issue

### DIFF
--- a/src/Api/Store/StoreCollection.php
+++ b/src/Api/Store/StoreCollection.php
@@ -43,13 +43,13 @@ class StoreCollection extends AbstractCollection
     }
 
     /**
-     * @param $idOrName
+     * @param int|string $idOrName
      *
      * @return null|StoreResource
      */
     public function select($idOrName)
     {
-        if (is_int($idOrName) | ctype_digit($idOrName)) {
+        if (is_int($idOrName) || ctype_digit($idOrName)) {
             return $this->getById($idOrName);
         }
 

--- a/src/Http/Middleware/RateLimitHandler.php
+++ b/src/Http/Middleware/RateLimitHandler.php
@@ -57,7 +57,9 @@ class RateLimitHandler
      */
     public function delay($count, ResponseInterface $response)
     {
-        $waitMS = (int) ceil($response->getHeaderLine('X-RateLimit-Wait') * 1000);
+        $waitS  = (float) $response->getHeaderLine('X-RateLimit-Wait');
+        $waitMS = (int) ceil($waitS * 1000);
+
         if (null !== $this->logger) {
             $this->logger->notice(sprintf('Request throttled for %d ms', $waitMS));
         }

--- a/tests/unit/Http/Middleware/RateLimitHandlerTest.php
+++ b/tests/unit/Http/Middleware/RateLimitHandlerTest.php
@@ -72,10 +72,9 @@ class RateLimitHandlerTest extends TestCase
 
     public function testDelay()
     {
-        $limitWait = 440;
+        $limitWait = '440';
         $response  = $this->createMock(Message\ResponseInterface::class);
         $response
-            ->expects($this->once())
             ->method('getHeaderLine')
             ->with('X-RateLimit-Wait')
             ->willReturn($limitWait);
@@ -84,6 +83,21 @@ class RateLimitHandlerTest extends TestCase
             ->expects($this->once())
             ->method('notice');
 
-        $this->assertEquals($limitWait * 1000, $this->instance->delay(null, $response));
+        $this->assertSame($limitWait * 1000, $this->instance->delay(null, $response));
+    }
+
+    public function testDelayWhenHeaderIsNotProvided()
+    {
+        $response  = $this->createMock(Message\ResponseInterface::class);
+        $response
+            ->method('getHeaderLine')
+            ->with('X-RateLimit-Wait')
+            ->willReturn('');
+
+        $this->logger
+            ->expects($this->once())
+            ->method('notice');
+
+        $this->assertSame(0, $this->instance->delay(0, $response));
     }
 }


### PR DESCRIPTION
### Reason for this PR
This PR fix an issue on php >= 8.1 if `X-RateLimit-Wait` is not defined in the response.
