### PR TITLE
Make available the order operation 'deliver'

### DIFF
--- a/src/Api/Order/OrderOperation.php
+++ b/src/Api/Order/OrderOperation.php
@@ -21,6 +21,7 @@ class OrderOperation extends Operation\AbstractBulkOperation
     public const TYPE_ACKNOWLEDGE      = 'acknowledge';
     public const TYPE_UNACKNOWLEDGE    = 'unacknowledge';
     public const TYPE_UPLOAD_DOCUMENTS = 'upload-documents';
+    public const TYPE_DELIVER          = 'deliver';
 
     /**
      * @var array
@@ -34,6 +35,7 @@ class OrderOperation extends Operation\AbstractBulkOperation
         self::TYPE_ACKNOWLEDGE,
         self::TYPE_UNACKNOWLEDGE,
         self::TYPE_UPLOAD_DOCUMENTS,
+        self::TYPE_DELIVER,
     ];
 
     /**


### PR DESCRIPTION
### Reason for this PR
The current PR makes the order operation 'deliver' available.
https://developer.shopping-feed.com/api/95a3d1e32e9c7-deliver-an-order

### What does the PR do
It adds the operation 'deliver' to the list of allowed ones




