### PR TITLE
Adding getLatestShipDate to OrderRessource

### DIFF
--- a/src/Api/Order/OrderResource.php
+++ b/src/Api/Order/OrderResource.php
@@ -65,6 +65,14 @@ class OrderResource extends Resource\AbstractResource
     }
 
     /**
+     * @return \DateTimeImmutable
+     */
+    public function getLatestShipDate()
+    {
+        return $this->getPropertyDatetime('latestShipDate');
+    }
+    
+    /**
      * @return array
      */
     public function getShippingAddress()


### PR DESCRIPTION
The "latestShipDate" property must be added

### Reason for this PR
Add latestShipDate property to OrderRessource

### What does the PR do
Add latestShipDate property to OrderRessource

### How to test
$order->getLatestShipDate()->format('d/m/Y H:i');


