### PR TITLE
Allow to view all orderItem properties

### DIFF
--- a/src/Api/Order/OrderItem.php
+++ b/src/Api/Order/OrderItem.php
@@ -7,9 +7,19 @@ namespace ShoppingFeed\Sdk\Api\Order;
 class OrderItem
 {
     /**
+     * @var int
+     */
+    private $id;
+
+    /**
      * @var string
      */
     private $reference;
+
+    /**
+     * @var string
+     */
+    private $status;
 
     /**
      * @var int
@@ -22,22 +32,88 @@ class OrderItem
     private $unitPrice;
 
     /**
+     * @var null|float
+     */
+    private $commission;
+
+    /**
      * @var float
      */
     private $taxAmount;
 
     /**
-     * @param string $reference The product's reference
-     * @param int    $quantity  Number product's occurrence in cart
-     * @param float  $price     The price for a single unit of the reference (not price * quantity)
-     * @param float  $taxAmount The tax amount of the item price
+     * @var float
      */
-    public function __construct($reference, $quantity, $price, $taxAmount)
+    private $ecotaxAmount;
+
+    /**
+     * @var string
+     */
+    private $channelReference;
+
+    /**
+     * @var null|array
+     */
+    private $additionalFields;
+
+    /**
+     * @var null|string
+     */
+    private $name;
+
+    /**
+     * @var null|string
+     */
+    private $image;
+
+    /**
+     * @param int $id The product's id
+     * @param string $reference The product's reference
+     * @param string $status The product's status
+     * @param int $quantity Number product's occurrence in cart
+     * @param float $price The price for a single unit of the reference (not price * quantity)
+     * @param null|float $commission The commission taken by the channel for this item
+     * @param float $taxAmount The tax amount of the item price
+     * @param float $ecotaxAmount The ecotax amount of the item price
+     * @param string $channelReference The channel reference of the product
+     * @param null|array $additionalFields A key / value object containing additional marketplace fields for the item
+     * @param null|string $name The product's name
+     * @param null|string $image The main image of the product
+     */
+    public function __construct(
+        $id,
+        $reference,
+        $status,
+        $quantity,
+        $price,
+        $commission,
+        $taxAmount,
+        $ecotaxAmount,
+        $channelReference,
+        $additionalFields,
+        $name,
+        $image
+    ) {
+        $this->id               = $id;
+        $this->reference        = $reference;
+        $this->status           = $status;
+        $this->quantity         = $quantity;
+        $this->unitPrice        = $price;
+        $this->commission       = $commission;
+        $this->taxAmount        = $taxAmount;
+        $this->ecotaxAmount     = $ecotaxAmount;
+        $this->channelReference = $channelReference;
+        $this->additionalFields = $additionalFields;
+        $this->name             = $name;
+        $this->image            = $image;
+    }
+
+    /**
+     * @return int
+     */
+    public function getId()
     {
-        $this->reference = $reference;
-        $this->quantity  = $quantity;
-        $this->unitPrice = $price;
-        $this->taxAmount = $taxAmount;
+        return $this->id;
     }
 
     /**
@@ -46,6 +122,14 @@ class OrderItem
     public function getReference()
     {
         return $this->reference;
+    }
+
+    /**
+     * @return string
+     */
+    public function getStatus()
+    {
+        return $this->status;
     }
 
     /**
@@ -65,11 +149,59 @@ class OrderItem
     }
 
     /**
+     * @return null|float
+     */
+    public function getCommission()
+    {
+        return $this->commission;
+    }
+
+    /**
      * @return float
      */
     public function getTaxAmount()
     {
         return $this->taxAmount;
+    }
+
+    /**
+     * @return float
+     */
+    public function getEcotaxAmount()
+    {
+        return $this->ecotaxAmount;
+    }
+
+    /**
+     * @return string
+     */
+    public function getChannelReference()
+    {
+        return $this->channelReference;
+    }
+
+    /**
+     * @return array
+     */
+    public function getAdditionalFields()
+    {
+        return $this->additionalFields;
+    }
+
+    /**
+     * @return null|string
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * @return null|string
+     */
+    public function getImage()
+    {
+        return $this->image;
     }
 
     /**
@@ -86,10 +218,18 @@ class OrderItem
     public function toArray()
     {
         return [
-            'reference' => $this->getReference(),
-            'quantity'  => $this->getQuantity(),
-            'price'     => $this->getUnitPrice(),
-            'taxAmount' => $this->getTaxAmount(),
+            'id'               => $this->getId(),
+            'reference'        => $this->getReference(),
+            'status'           => $this->getStatus(),
+            'quantity'         => $this->getQuantity(),
+            'price'            => $this->getUnitPrice(),
+            'commission'       => $this->getCommission(),
+            'taxAmount'        => $this->getTaxAmount(),
+            'ecotaxAmount'     => $this->getEcotaxAmount(),
+            'channelReference' => $this->getChannelReference(),
+            'additionalFields' => $this->getAdditionalFields(),
+            'name'             => $this->getName(),
+            'image'            => $this->getImage(),
         ];
     }
 }

--- a/src/Api/Order/OrderItem.php
+++ b/src/Api/Order/OrderItem.php
@@ -93,7 +93,8 @@ class OrderItem
         $additionalFields,
         $name,
         $image
-    ) {
+    )
+    {
         $this->id               = $id;
         $this->reference        = $reference;
         $this->status           = $status;

--- a/src/Api/Order/OrderItemCollection.php
+++ b/src/Api/Order/OrderItemCollection.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ShoppingFeed\Sdk\Api\Order;
 
 class OrderItemCollection implements \Countable, \IteratorAggregate
@@ -18,7 +19,20 @@ class OrderItemCollection implements \Countable, \IteratorAggregate
         $instance = new self;
         foreach ($items as $item) {
             $instance->add(
-                new OrderItem($item['reference'], $item['quantity'], $item['price'], $item['taxAmount'])
+                new OrderItem(
+                    $item['id'],
+                    $item['reference'],
+                    $item['status'],
+                    $item['quantity'],
+                    $item['price'],
+                    $item['commission'],
+                    $item['taxAmount'],
+                    $item['ecotaxAmount'],
+                    $item['channelReference'],
+                    $item['additionalFields'],
+                    $item['name'],
+                    $item['image']
+                )
             );
         }
 

--- a/tests/unit/Api/Order/OrderItemCollectionTest.php
+++ b/tests/unit/Api/Order/OrderItemCollectionTest.php
@@ -8,17 +8,33 @@ class OrderItemCollectionTest extends TestCase
 {
     private $items = [
         [
-            'reference' => 'a',
-            'quantity'  => 1,
-            'price'     => 2,
-            'taxAmount' => 7.99,
+            'id'               => 123,
+            'reference'        => 'a',
+            'status'           => '',
+            'quantity'         => 1,
+            'price'            => 2,
+            'commission'       => null,
+            'taxAmount'        => 7.99,
+            'ecotaxAmount'     => 0,
+            'channelReference' => 'ref',
+            'additionalFields' => ['taxRate' => 20],
+            'name'             => null,
+            'image'            => null,
         ],
         [
-            'reference' => 'b',
-            'quantity'  => 2,
-            'price'     => 3,
-            'taxAmount' => 4.99,
-        ]
+            'id'               => 456,
+            'reference'        => 'b',
+            'status'           => '',
+            'quantity'         => 2,
+            'price'            => 3,
+            'commission'       => null,
+            'taxAmount'        => 4.99,
+            'ecotaxAmount'     => 0,
+            'channelReference' => 'ref2',
+            'additionalFields' => ['taxRate' => 45],
+            'name'             => null,
+            'image'            => null,
+        ],
     ];
 
     public function testCreateCollectionFromArrayOfRemoteProperties()
@@ -37,23 +53,29 @@ class OrderItemCollectionTest extends TestCase
         $instance = OrderItemCollection::fromProperties($this->items);
         $items    = $instance->getIterator()->getArrayCopy();
 
-        $firstOne = new OrderItem(
-            $this->items[0]['reference'],
-            $this->items[0]['quantity'],
-            $this->items[0]['price'],
-            $this->items[0]['taxAmount']
-        );
+        $firstOne  = $this->createItem($this->items[0]);
+        $secondOne = $this->createItem($this->items[1]);
 
         $this->assertEquals($items[0], $firstOne);
-
-        $secondOne = new OrderItem(
-            $this->items[1]['reference'],
-            $this->items[1]['quantity'],
-            $this->items[1]['price'],
-            $this->items[1]['taxAmount']
-        );
-
         $this->assertEquals($items[1], $secondOne);
+    }
+
+    private function createItem(array $item): OrderItem
+    {
+        return new OrderItem(
+            $item['id'],
+            $item['reference'],
+            $item['status'],
+            $item['quantity'],
+            $item['price'],
+            $item['commission'],
+            $item['taxAmount'],
+            $item['ecotaxAmount'],
+            $item['channelReference'],
+            $item['additionalFields'],
+            $item['name'],
+            $item['image']
+        );
     }
 
     public function testCollectionCanBeRevertedBackToArray()

--- a/tests/unit/Api/Order/OrderItemTest.php
+++ b/tests/unit/Api/Order/OrderItemTest.php
@@ -13,31 +13,37 @@ class OrderItemTest extends TestCase
 
     public function setUp(): void
     {
-        $this->instance = new OrderItem('a', 2, 9.99, 7.99);
+        $this->instance = new OrderItem(
+            123,
+            'a',
+            '',
+            2,
+            9.99,
+            null,
+            7.99,
+            0,
+            'A00001',
+            ['taxRate' => 20],
+            'ASPIRO 2000',
+            'http://url.com/image.png'
+        );
     }
 
-    public function testGetReference()
+    public function testGetters()
     {
-        $this->assertSame('a', $this->instance->getReference(), 'Reference is the first constructor arg');
-    }
+        $this->assertSame(123, $this->instance->getId());
+        $this->assertSame('a', $this->instance->getReference());
+        $this->assertSame('', $this->instance->getStatus());
+        $this->assertSame(2, $this->instance->getQuantity());
+        $this->assertSame(9.99, $this->instance->getUnitPrice());
+        $this->assertNull($this->instance->getCommission());
+        $this->assertSame(7.99, $this->instance->getTaxAmount());
+        $this->assertSame(0, $this->instance->getEcotaxAmount());
+        $this->assertSame('A00001', $this->instance->getChannelReference());
+        $this->assertSame(['taxRate' => 20], $this->instance->getAdditionalFields());
+        $this->assertSame('ASPIRO 2000', $this->instance->getName());
+        $this->assertSame('http://url.com/image.png', $this->instance->getImage());
 
-    public function testGetQuantity()
-    {
-        $this->assertSame(2, $this->instance->getQuantity(), 'Quantity is the second constructor arg');
-    }
-
-    public function testGetUnitPrice()
-    {
-        $this->assertSame(9.99, $this->instance->getUnitPrice(), 'Unit Price is the third constructor arg');
-    }
-
-    public function testGetTaxAmount()
-    {
-        $this->assertSame(7.99, $this->instance->getTaxAmount(), 'TaxAmount is the last constructor arg');
-    }
-
-    public function testGetTotalPriceWithComputeRowPrice()
-    {
         $this->assertSame(19.98, $this->instance->getTotalPrice());
     }
 }

--- a/tests/unit/Api/Order/OrderResourceTest.php
+++ b/tests/unit/Api/Order/OrderResourceTest.php
@@ -100,10 +100,18 @@ class OrderResourceTest extends Sdk\Test\Api\AbstractResourceTest
         $this->initHalResourceProperties([
             'items' => [
                 [
-                    'reference' => 'a',
-                    'price'     => 9.99,
-                    'taxAmount' => 7.99,
-                    'quantity'  => 1,
+                    'id'               => 123,
+                    'reference'        => 'a',
+                    'status'           => '',
+                    'quantity'         => 1,
+                    'price'            => 9.99,
+                    'commission'       => null,
+                    'taxAmount'        => 7.99,
+                    'ecotaxAmount'     => 0,
+                    'channelReference' => 'ref',
+                    'additionalFields' => ['taxRate' => 20],
+                    'name'             => null,
+                    'image'            => null,
                 ],
             ],
         ]);


### PR DESCRIPTION
### Link to the issue
https://github.com/shoppingflux/php-sdk/issues/122

### Reason for this PR
We want to be able to retrieve all item properties for a given order

### What does the PR do
Now, we return this list of properties:
- id
- reference
- status
- quantity
- price
- commission
- taxAmount
- ecotaxAmount
- channelReference
- additionalFields
- name
- image

### How to test
See UTs

```
foreach($orderApi->getAll($criteria['filters']) as $order) {
  foreach ($order->getItems() as $item) {
    //now, returns all fields
    $item->toArray()
  } 
} 
```


