### PR TITLE
Fix creation of order references in legacy order operations

### DIFF
--- a/src/Api/Order/OrderOperation.php
+++ b/src/Api/Order/OrderOperation.php
@@ -234,7 +234,7 @@ class OrderOperation extends AbstractBulkOperation implements OperationInterface
 
     private function createReference(string $reference, string $channelName): Api\Order\Identifier\OrderIdentifier
     {
-        return new class implements Api\Order\Identifier\OrderIdentifier {
+        return new class($reference, $channelName) implements Api\Order\Identifier\OrderIdentifier {
             /**
              * @var string
              */
@@ -257,8 +257,8 @@ class OrderOperation extends AbstractBulkOperation implements OperationInterface
             public function toArray(): array
             {
                 return [
-                    'reference'    => $this->reference,
-                    'channel_name' => $this->channelName,
+                    'reference'   => $this->reference,
+                    'channelName' => $this->channelName,
                 ];
             }
         };


### PR DESCRIPTION
### Reason for this PR
The (legacy) `ShoppingFeed\Sdk\Api\Order\OrderOperation` class no longer works starting with version **0.10.0**.

### What does the PR do
Fixes the issues in the class to restore functionality.