### PR TITLE
Fix creation of order references in legacy order operations

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -181,11 +181,6 @@ parameters:
 			path: src/Api/Order/OrderItemCollection.php
 
 		-
-			message: "#^Class class@anonymous/Api/Order/OrderOperation\\.php\\:237 constructor invoked with 0 parameters, 2 required\\.$#"
-			count: 1
-			path: src/Api/Order/OrderOperation.php
-
-		-
 			message: "#^Method ShoppingFeed\\\\Sdk\\\\Api\\\\Order\\\\OrderOperation\\:\\:refund\\(\\) has parameter \\$products with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Api/Order/OrderOperation.php

--- a/src/Api/Order/OrderOperation.php
+++ b/src/Api/Order/OrderOperation.php
@@ -234,7 +234,7 @@ class OrderOperation extends AbstractBulkOperation implements OperationInterface
 
     private function createReference(string $reference, string $channelName): Api\Order\Identifier\OrderIdentifier
     {
-        return new class implements Api\Order\Identifier\OrderIdentifier {
+        return new class($reference, $channelName) implements Api\Order\Identifier\OrderIdentifier {
             /**
              * @var string
              */
@@ -252,13 +252,13 @@ class OrderOperation extends AbstractBulkOperation implements OperationInterface
             }
 
             /**
-             * @return array{reference: string, channel_name: string}
+             * @return array{reference: string, channelName: string}
              */
             public function toArray(): array
             {
                 return [
-                    'reference'    => $this->reference,
-                    'channel_name' => $this->channelName,
+                    'reference'   => $this->reference,
+                    'channelName' => $this->channelName,
                 ];
             }
         };


### PR DESCRIPTION
### Reason for this PR
Created from: https://github.com/shoppingflux/php-sdk/pull/128

The (legacy) `ShoppingFeed\Sdk\Api\Order\OrderOperation` class no longer works starting with version **0.10.0**.

### What does the PR do
Fixes the issues in the class to restore functionality.