### PR TITLE
Make PaginatedResourceCollection usable without Resource object

### DIFF
--- a/src/Resource/PaginatedResourceCollection.php
+++ b/src/Resource/PaginatedResourceCollection.php
@@ -6,17 +6,22 @@ use ShoppingFeed\Sdk\Hal;
 class PaginatedResourceCollection extends AbstractResource implements \IteratorAggregate, \Countable
 {
     /**
-     * @var string
+     * @var ?string
      */
     private $resourceClass;
 
     /**
+     * Provide your resource class name if you want that collection return
+     * those specific resource class rather than an HalResource
+     *
      * @param Hal\HalResource $resource
-     * @param string          $resourceClass
+     * @param ?string         $resourceClass
      */
-    public function __construct(Hal\HalResource $resource, $resourceClass)
+    public function __construct(Hal\HalResource $resource, $resourceClass = null)
     {
-        $this->resourceClass = (string) $resourceClass;
+        if (null !== $resourceClass) {
+            $this->resourceClass = (string) $resourceClass;
+        }
 
         parent::__construct($resource, false);
     }
@@ -90,21 +95,20 @@ class PaginatedResourceCollection extends AbstractResource implements \IteratorA
         return new static($resource, $this->resourceClass);
     }
 
-    /**
-     * @inheritdoc
-     */
     #[\ReturnTypeWillChange]
     public function getIterator()
     {
         $data = current($this->resource->getAllResources()) ?: [];
+
         foreach ($data as $item) {
-            yield new $this->resourceClass($item);
+            if (null !== $this->resourceClass) {
+                $item = new $this->resourceClass($item);
+            }
+
+            yield $item;
         }
     }
 
-    /**
-     * @inheritdoc
-     */
     #[\ReturnTypeWillChange]
     public function count()
     {


### PR DESCRIPTION
### Reason for this PR
This PR makes PaginatedResourceCollection usable without dedicated Resource object. In such case, You will get a list of HalResource.

```php
$apiHost = 'https://api.shopping-feed.com';
$storeId  = 99999;
$token    = '...';

$options = new Client\ClientOptions();
$options->setBaseUri($apiHost);
$options->setHttpAdapter(new Http\Adapter\GuzzleHTTPAdapter($options));

$client = new Hal\HalClient($options->getBaseUri(), $options->getHttpAdapter());
$client = $client->withToken($token);

$resource = $client->request('GET', "/v1/store/$storeId/order", ['query' => ['limit' => 10]]);

$iterator = new PaginatedResourceIterator(
    new PaginatedResourceCollection($resource)
);

$orders = [];

foreach ($iterator as $order) {
    $orders[] = $order->getProperty('id');
}
```


