### PR TITLE
SFCORE-3435: Handle upload document operation

### DIFF
--- a/src/Api/Order/Operation.php
+++ b/src/Api/Order/Operation.php
@@ -5,6 +5,8 @@ namespace ShoppingFeed\Sdk\Api\Order;
 use ArrayAccess;
 use ArrayObject;
 use Exception;
+use RuntimeException;
+use ShoppingFeed\Sdk\Api\Order\Document\AbstractDocument;
 use ShoppingFeed\Sdk\Api\Order\Identifier\OrderIdentifier;
 use ShoppingFeed\Sdk\Exception\InvalidArgumentException;
 use ShoppingFeed\Sdk\Hal;
@@ -212,6 +214,12 @@ final class Operation extends AbstractBulkOperation implements OperationInterfac
 
     private function populateRequests(string $type, Hal\HalLink $link, ArrayAccess $requests): void
     {
+        // Upload documents require dedicated processing because of file upload specificities
+        if (self::TYPE_UPLOAD_DOCUMENTS === $type) {
+            $this->populateRequestsForUploadDocuments($link, $requests);
+            return;
+        }
+
         $this->eachBatch(
             function (array $chunk) use ($type, $link, &$requests) {
                 $requests[] = $link->createRequest(
@@ -222,5 +230,47 @@ final class Operation extends AbstractBulkOperation implements OperationInterfac
             },
             $type
         );
+    }
+
+    /**
+     * Create requests for upload documents operation. We batch request by 20
+     * to not send too many files at once.
+     */
+    private function populateRequestsForUploadDocuments(Hal\HalLink $link, \ArrayAccess $requests): void
+    {
+        $type = self::TYPE_UPLOAD_DOCUMENTS;
+
+        foreach (array_chunk($this->getOperations($type), 20) as $batch) {
+            $body   = [];
+            $orders = [];
+
+            foreach ($batch as $operation) {
+                /** @var AbstractDocument $document */
+                $document = $operation['document'];
+                $resource = fopen($document->getPath(), 'rb');
+
+                if (false === $resource) {
+                    throw new RuntimeException(
+                        sprintf('Unable to read "%s"', $document->getPath())
+                    );
+                }
+
+                $body[]   = ['name' => 'files[]', 'contents' => $resource];
+                $orders[] = [
+                    'reference'   => $operation['reference'],
+                    'channelName' => $operation['channelName'],
+                    'documents'   => [['type' => $document->getType()]],
+                ];
+            }
+
+            $body[] = ['name' => 'body', 'contents' => json_encode(['order' => $orders])];
+
+            $requests[] = $link->createRequest(
+                'POST',
+                ['operation' => $type],
+                $body,
+                ['Content-Type' => 'multipart/form-data']
+            );
+        }
     }
 }

--- a/src/Api/Order/Operation.php
+++ b/src/Api/Order/Operation.php
@@ -239,7 +239,7 @@ final class Operation extends AbstractBulkOperation implements OperationInterfac
      *
      * @param ArrayAccess<int, RequestInterface> $requests
      */
-    private function populateRequestsForUploadDocuments(Hal\HalLink $link, \ArrayAccess $requests): void
+    private function populateRequestsForUploadDocuments(Hal\HalLink $link, ArrayAccess $requests): void
     {
         $type = self::TYPE_UPLOAD_DOCUMENTS;
 

--- a/src/Api/Order/Operation.php
+++ b/src/Api/Order/Operation.php
@@ -253,15 +253,14 @@ final class Operation extends AbstractBulkOperation implements OperationInterfac
                 $resource = fopen($document->getPath(), 'rb');
 
                 if (false === $resource) {
-                    throw new RuntimeException(
-                        sprintf('Unable to read "%s"', $document->getPath())
-                    );
+                    throw new RuntimeException(sprintf('Unable to read "%s"', $document->getPath()));
                 }
 
                 $body[]   = ['name' => 'files[]', 'contents' => $resource];
                 $orders[] = [
-                    'reference'   => $operation['reference'],
-                    'channelName' => $operation['channelName'],
+                    'id'          => $operation['id'] ?? null,
+                    'reference'   => $operation['reference'] ?? null,
+                    'channelName' => $operation['channelName'] ?? null,
                     'documents'   => [['type' => $document->getType()]],
                 ];
             }

--- a/src/Api/Order/Operation.php
+++ b/src/Api/Order/Operation.php
@@ -5,6 +5,7 @@ namespace ShoppingFeed\Sdk\Api\Order;
 use ArrayAccess;
 use ArrayObject;
 use Exception;
+use Psr\Http\Message\RequestInterface;
 use RuntimeException;
 use ShoppingFeed\Sdk\Api\Order\Document\AbstractDocument;
 use ShoppingFeed\Sdk\Api\Order\Identifier\OrderIdentifier;
@@ -235,6 +236,8 @@ final class Operation extends AbstractBulkOperation implements OperationInterfac
     /**
      * Create requests for upload documents operation. We batch request by 20
      * to not send too many files at once.
+     *
+     * @param ArrayAccess<int, RequestInterface> $requests
      */
     private function populateRequestsForUploadDocuments(Hal\HalLink $link, \ArrayAccess $requests): void
     {


### PR DESCRIPTION
### Link to the issue
https://shopping-feed.atlassian.net/browse/SFCORE-3435

### Reason for this PR
Add back functionality to manage upload document operation, inadvertently deleted in this PR: https://github.com/shoppingflux/php-sdk/pull/119

### What does the PR do
Restore the deleted code, than add the compatibility with the new version.

### How to test
```php
<?php
namespace ShoppingFeed\Sdk;

use Throwable;

require 'vendor/autoload.php';

// API client configuration
$apiUrl = 'http://localhost';
$token  = '<TOKEN>';

// Order configuration
$reference   = '#1A';
$channel     = 'amazon';
$id          = 1234;
$invoiceFile = '<PATH>/invoice.pdf';

$credential = new Credential\Token($token);
$options    = (new Client\ClientOptions())->setBaseUri($apiUrl);

# Deprecated old version
# $operation = new Api\Order\OrderOperation();
# $operation->uploadDocument($reference, $channel, new Api\Order\Document\Invoice($invoiceFile));

# New version
$operation = new Api\Order\Operation();
$operation->uploadDocument(new Id($id), new Api\Order\Document\Invoice($invoiceFile));

$orderApi = Client\Client::createSession($credential, $options)->getMainStore()->getOrderApi();
$orderApi->execute($operation);
```


