### PR TITLE
Fix OrderOperation::count()

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,13 +1,13 @@
-<phpunit bootstrap="./vendor/autoload.php" colors="true">
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="./vendor/autoload.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage processUncoveredFiles="true">
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+  </coverage>
   <testsuites>
     <testsuite name="ShoppingFeed\\Sdk">
       <directory>./tests/unit</directory>
     </testsuite>
   </testsuites>
-
-  <filter>
-    <whitelist processUncoveredFilesFromWhitelist="true">
-      <directory suffix=".php">src</directory>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/src/Api/Order/OrderOperation.php
+++ b/src/Api/Order/OrderOperation.php
@@ -221,6 +221,16 @@ class OrderOperation extends AbstractBulkOperation implements OperationInterface
     }
 
     /**
+     * Count operations
+     *
+     * @param string $filter
+     */
+    public function count($filter = null): int
+    {
+        return $this->operation->count($filter);
+    }
+
+    /**
      * Execute all declared operations
      */
     public function execute(Hal\HalLink $link): OrderOperationResult

--- a/tests/unit/Api/Order/OrderOperationTest.php
+++ b/tests/unit/Api/Order/OrderOperationTest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace ShoppingFeed\Sdk\Test\Api\Order;
+
+use PHPUnit\Framework\TestCase;
+use ShoppingFeed\Sdk\Api\Order\OrderOperation;
+
+class OrderOperationTest extends TestCase
+{
+    public function testCount(): void
+    {
+        $operation = new OrderOperation();
+        $operation
+            ->accept('ORDER123', 'ChannelA')
+            ->cancel('ORDER456', 'ChannelB')
+            ->ship('ORDER789', 'ChannelC');
+
+        $this->assertSame(3, $operation->count());
+    }
+}


### PR DESCRIPTION
### Reason for this PR
The OrderOperation::count() method no longer works as expected.

### Steps to reproduce
- Given I add operations to OrderOperation : 
```php
$operation = new OrderOperation();
$operation
    ->accept('ORDER123', 'ChannelA')
    ->cancel('ORDER456', 'ChannelB')
    ->ship('ORDER789', 'ChannelC');
```
- When I count operations
```php
$operation->count()
```

### Observed bug on master
- Then I get 0

### Expected result on branch
- Then I get 3


